### PR TITLE
remove Dockerfile for now

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,0 @@
-FROM golang:1.10
-ADD . /go/src/github.com/fullstorydev/grpcui
-WORKDIR /go/src/github.com/fullstorydev/grpcui
-RUN make deps install


### PR DESCRIPTION
Previous PR (#10) added the Dockerfile. But it's not quite the shape we want for an "official" Dockerfile in the repo. For now, we'll go without in this repo and add one later once we have a better idea for what we want the image to look like. (The one being removed uses Go as its base image, which means the resulting image is a bit heavy-weight, including the Go SDK which is not necessary for grpcui at runtime.)