### PR TITLE
fix -unix flag; add -max-time and -max-msg-sz flags

### DIFF
--- a/cmd/grpcui/unix.go
+++ b/cmd/grpcui/unix.go
@@ -2,10 +2,8 @@
 
 package main
 
-import "flag"
-
 var (
-	unix = flag.Bool("unix", false,
+	unix = flags.Bool("unix", false,
 		`Indicates that the server address is the path to a Unix domain socket.`)
 )
 


### PR DESCRIPTION
Effectively adds three new flags to grpcui

* `-unix`, to support communicating with servers listening on a unix domain socket (this is a bug fix: this flag was supposed to be present before but was incorrectly omitted)
* `-max-time`, to support a deadline for all RPC invocations (it applies per RPC request)
* `-max-msg-sz`, to support changing the gRPC library's default limit of 4 megabytes for received response messages.

This branch also tweaks the implementation for two other flags, `-connect-timeout` and `-keepalive-time`: they now use `flags.Float64` instead of using `flags.String` and having to parse (`strconv.ParseFloat`) the value.

This fixes #17 and #18.