### PR TITLE
Enable automatic reconnection to server

### DIFF
--- a/cmd/grpcui/grpcui.go
+++ b/cmd/grpcui/grpcui.go
@@ -88,6 +88,10 @@ var (
 	veryVeryVerbose = flags.Bool("vvv", false, prettify(`
 		Enable the most verbose output, which includes traces of all HTTP
 		requests and responses.`))
+
+	autoReconnect = flags.Bool("autoReconnect", false, prettify(`
+		Automatically reconnect to grpc server when connection closed`))
+
 	serverName = flags.String("servername", "", prettify(`
 		Override servername when validating TLS certificate.`))
 
@@ -273,7 +277,12 @@ func main() {
 	if isUnixSocket != nil && isUnixSocket() {
 		network = "unix"
 	}
-	cc, err := grpcurl.BlockingDial(ctx, network, target, creds, opts...)
+	var cc *grpc.ClientConn
+	if *autoReconnect {
+		cc, err = BlockingDialAutoReconnect(ctx, network, target, creds, opts...)
+	} else {
+		cc, err = grpcurl.BlockingDial(ctx, network, target, creds, opts...)
+	}
 	if err != nil {
 		fail(err, "Failed to dial target host %q", target)
 	}
@@ -648,4 +657,68 @@ func logErrorf(format string, args ...interface{}) {
 func logInfof(format string, args ...interface{}) {
 	prefix := "INFO: " + time.Now().Format("2006/01/02 15:04:05") + " "
 	log.Printf(prefix+format, args...)
+}
+
+// Copy of grpcurl.BlockingDial that doesnt cancel the connection on errors
+func BlockingDialAutoReconnect(ctx context.Context, network, address string, creds credentials.TransportCredentials, opts ...grpc.DialOption) (*grpc.ClientConn, error) {
+	// grpc.Dial doesn't provide any information on permanent connection errors (like
+	// TLS handshake failures). So in order to provide good error messages, we need a
+	// custom dialer that can provide that info. That means we manage the TLS handshake.
+	result := make(chan interface{}, 1)
+
+	writeResult := func(res interface{}) {
+		// non-blocking write: we only need the first result
+		select {
+		case result <- res:
+		default:
+		}
+	}
+
+	dialer := func(address string, timeout time.Duration) (net.Conn, error) {
+		ctx, _ := context.WithTimeout(ctx, timeout)
+
+		conn, err := (&net.Dialer{}).Dial(network, address)
+		if err != nil {
+			writeResult(err)
+			return nil, err
+		}
+		if creds != nil {
+			conn, _, err = creds.ClientHandshake(ctx, address, conn)
+			if err != nil {
+				writeResult(err)
+				return nil, err
+			}
+		}
+		return conn, nil
+	}
+
+	// Even with grpc.FailOnNonTempDialError, this call will usually timeout in
+	// the face of TLS handshake errors. So we can't rely on grpc.WithBlock() to
+	// know when we're done. So we run it in a goroutine and then use result
+	// channel to either get the channel or fail-fast.
+	go func() {
+		opts = append(opts,
+			grpc.WithBlock(),
+			grpc.WithDialer(dialer),
+			grpc.WithInsecure(), // we are handling TLS, so tell grpc not to
+		)
+		conn, err := grpc.DialContext(ctx, address, opts...)
+		var res interface{}
+		if err != nil {
+			res = err
+		} else {
+			res = conn
+		}
+		writeResult(res)
+	}()
+
+	select {
+	case res := <-result:
+		if conn, ok := res.(*grpc.ClientConn); ok {
+			return conn, nil
+		}
+		return nil, res.(error)
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	}
 }


### PR DESCRIPTION
Not the cleanest PR, but a much needed feature.

It's really annoying when developing a service, needing to restart grpc ui each time you restart your server app.

I basically just copied the `grpcurl` dial command and removed the connection cancellation logic.