### PR TITLE
fix range validation for 64-bit signed ints

### DIFF
--- a/internal/resources/webform/webform.js
+++ b/internal/resources/webform/webform.js
@@ -1181,6 +1181,7 @@ window.initGRPCForm = function(services, invokeURI, metadataURI, debug) {
                 return 1;
             }
         }
+        var sgn = aNeg ? -1 : 1;
         var padLen = a.length - b.length;
         if (padLen > 0) {
             // a longer than b: pad b
@@ -1191,9 +1192,9 @@ window.initGRPCForm = function(services, invokeURI, metadataURI, debug) {
         }
         // now we can safely use lexical compare
         if (a < b) {
-            return -1;
+            return -sgn;
         } else if (a > b) {
-            return 1;
+            return sgn;
         }
         return 0;
     }


### PR DESCRIPTION
Fixes #27 

When the web form validates entry of 64-bit signed ints, the logic was simply broken and would not accept any negative values, unless they were actually *less* than the supposed minimum (whoops).