### PR TITLE
omit ServerReflection from service list

### DIFF
--- a/cmd/grpcui/grpcui.go
+++ b/cmd/grpcui/grpcui.go
@@ -470,6 +470,9 @@ func getMethods(source grpcurl.DescriptorSource, configs map[string]*svcConfig) 
 
 	var descs []*desc.MethodDescriptor
 	for _, svc := range allServices {
+		if svc == "grpc.reflection.v1alpha.ServerReflection" {
+			continue
+		}
 		d, err := source.FindSymbol(svc)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
The ServerReflection service is not useful through grpcui and is often just noise -- especially if it sorts to the top of the service list and then ends up being the default service selection when opening the UI.