### PR TITLE
vet with modules

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,11 +5,11 @@ matrix:
   include:
     # TODO: update the version used to vet to Go 1.13
     - go: 1.11.x
-      env:
-      - GO111MODULE=off
-      - VET=1
+      env: GO111MODULE=off
     - go: 1.11.x
-      env: GO111MODULE=on
+      env:
+      - GO111MODULE=on
+      - VET=1
     - go: 1.12.x
       env: GO111MODULE=off
     - go: 1.12.x


### PR DESCRIPTION
Previously, the vet step was done with modules turned off. This allowed versions of dependencies to be unpinned and pick up newer versions that include newer deprecations. The deprecations made vet unhappy.

This pins the deps during the vet step because we are not at this time intending to move to the new protobuf API (though the old one has now been deprecated). We'll move to the new APIs before too long, but it's a non-trivial amount of work and there are other deps which still use the old API...