### PR TITLE
fix goreleaser config; use Go 1.13 in docker build

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -11,14 +11,14 @@ builds:
     ldflags:
       - -s -w -X main.version=v{{.Version}}
 
-archive:
-  format: tar.gz
-  format_overrides:
-    - goos: windows
-      format: zip
-  replacements:
-    amd64: x86_64
-    386: x86_32
-    darwin: osx
-  files:
-    - LICENSE
+archives:
+  - format: tar.gz
+    format_overrides:
+      - goos: windows
+        format: zip
+    replacements:
+      amd64: x86_64
+      386: x86_32
+      darwin: osx
+    files:
+      - LICENSE

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.11.10-alpine as builder
+FROM golang:1.13-alpine as builder
 MAINTAINER FullStory Engineering
 
 # currently, a module build requires gcc (so Go tool can build


### PR DESCRIPTION
#69 pins a newer version of goreleaser. This fixes the config to work with that newer version. It also updates the Dockerfile so that we use Go 1.13 to build the official image.