### PR TITLE
tweak Dockerfile: no need to install gcc to build modules w/ go 1.13

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,6 @@
 FROM golang:1.13-alpine as builder
 MAINTAINER FullStory Engineering
 
-# currently, a module build requires gcc (so Go tool can build
-# module-aware versions of std library; it ships only w/ the
-# non-module versions)
-RUN apk update && apk add --no-cache ca-certificates git gcc g++ libc-dev
 # create non-privileged group and user
 RUN addgroup -S grpcui && adduser -S grpcui -G grpcui
 


### PR DESCRIPTION
With Go 1.11, the Go SDK shipped with only non-module binaries for the standard library. So building something with modules required re-building the standard library, which required having GCC and some other tools installed.

But with Go 1.13, the module versions of the standard libs are included. So we can now skip this step in setting up the Docker container for building grpcui using modules.