### PR TITLE
Get duration right after call completes

### DIFF
--- a/internal/resources/webform/webform.js
+++ b/internal/resources/webform/webform.js
@@ -2125,6 +2125,7 @@ window.initGRPCForm = function(services, invokeURI, metadataURI, debug, headers)
                 data: JSON.stringify({timeout_seconds: timeout, metadata: metadata, data: data}),
             })
             .done(function(responseData) {
+                const durationMS = window.performance.now() - startTime;
                 if (responseData.headers instanceof Array && responseData.headers.length > 0) {
                     var hdrs = $("#grpc-response-headers");
                     hdrs.empty();
@@ -2178,7 +2179,7 @@ window.initGRPCForm = function(services, invokeURI, metadataURI, debug, headers)
                 if (responseData.error) {
                     addHistory({
                         ...history,
-                        durationMS: window.performance.now() - startTime,
+                        durationMS: durationMS,
                         responseData: responseData,
                     });
                     $("#grpc-response-error").show();
@@ -2197,7 +2198,7 @@ window.initGRPCForm = function(services, invokeURI, metadataURI, debug, headers)
                 } else {
                     addHistory({
                         ...history,
-                        durationMS: window.performance.now() - startTime,
+                        durationMS: durationMS,
                         responseData: responseData,
                     });
                     $("#grpc-response-error").hide();


### PR DESCRIPTION
Capture the duration of the call right after it completes. Since the response is rendered as JSON now rather than HTML, this is less of an issue than it was before. But capturing it as quickly as possible is better.