### PR TITLE
standalone: support proto files as reflection alternative

### DIFF
--- a/files.go
+++ b/files.go
@@ -2,6 +2,7 @@ package grpcui
 
 import (
 	"github.com/jhump/protoreflect/desc"
+	"github.com/jhump/protoreflect/desc/protoparse"
 	"github.com/jhump/protoreflect/grpcreflect"
 	"golang.org/x/net/context"
 	"google.golang.org/grpc"
@@ -21,4 +22,11 @@ func AllFilesViaReflection(ctx context.Context, cc grpc.ClientConnInterface) ([]
 	cli.ListServices()
 	source := grpcurl.DescriptorSourceFromServer(ctx, cli)
 	return grpcurl.GetAllFiles(source)
+}
+
+// AllFilesViaReflection returns a slice that contains the file descriptors
+// for the given proto files
+func AllFilesViaProtoFiles(filenames ...string) ([]*desc.FileDescriptor, error) {
+	parser := protoparse.Parser{}
+	return parser.ParseFiles(filenames...)
 }

--- a/methods.go
+++ b/methods.go
@@ -8,6 +8,16 @@ import (
 	rpb "google.golang.org/grpc/reflection/grpc_reflection_v1alpha"
 )
 
+// AllMethodsForFiles returns a slice that contains the method descriptors
+// for all methods in the given files.
+func AllMethodsForFiles(descs []*desc.FileDescriptor) []*desc.MethodDescriptor {
+	var allMethods []*desc.MethodDescriptor
+	for _, fd := range descs {
+		allMethods = append(allMethods, AllMethodsForServices(fd.GetServices())...)
+	}
+	return allMethods
+}
+
 // AllMethodsForServices returns a slice that contains the method descriptors
 // for all methods in the given services.
 func AllMethodsForServices(descs []*desc.ServiceDescriptor) []*desc.MethodDescriptor {

--- a/standalone/standalone.go
+++ b/standalone/standalone.go
@@ -212,3 +212,18 @@ func HandlerViaReflection(ctx context.Context, cc grpc.ClientConnInterface, targ
 
 	return Handler(cc, target, m, f, opts...), nil
 }
+
+// HandlerViaProtoFiles uses the given proto files to determine the services
+// and methods supported by the server, and constructs a handler to serve the UI.
+//
+// The handler has the same properties as the one returned by Handler.
+func HandlerViaProtoFiles(ctx context.Context, cc grpc.ClientConnInterface, protoFiles []string, target string, opts ...HandlerOption) (http.Handler, error) {
+	f, err := grpcui.AllFilesViaProtoFiles(protoFiles...)
+	if err != nil {
+		return nil, err
+	}
+
+	m := grpcui.AllMethodsForFiles(f)
+
+	return Handler(cc, target, m, f, opts...), nil
+}


### PR DESCRIPTION
For cases where server reflection doesn't work, being able to simply
provide the proto files is a useful alternative.