### PR TITLE
Ability to have grpcui not fail-fast on connection errors

### DIFF
--- a/cmd/grpcui/grpcui.go
+++ b/cmd/grpcui/grpcui.go
@@ -759,7 +759,7 @@ func dial(ctx context.Context, network, addr string, creds credentials.Transport
 	if err := errCreds.err(); err != nil {
 		return nil, err
 	}
-	// otherwise, use the error the dialer last error
+	// otherwise, use the error the dialer last observed
 	if err := dialer.err(); err != nil {
 		return nil, err
 	}

--- a/cmd/grpcui/grpcui.go
+++ b/cmd/grpcui/grpcui.go
@@ -18,6 +18,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/fullstorydev/grpcurl"
@@ -79,6 +80,12 @@ var (
 	connectTimeout = flags.Float64("connect-timeout", 0, prettify(`
 		The maximum time, in seconds, to wait for connection to be established.
 		Defaults to 10 seconds.`))
+	connectFailFast = flags.Bool("connect-fail-fast", true, prettify(`
+		If true, non-temporary errors (such as "connection refused" during
+		initial connection will cause the program to immediately abort. This
+		is the default and is appropriate for interactive uses of grpcui. But
+		long-lived server use (like as a sidecar to a gRPC server) will prefer
+		to set this to false for more robust startup.`))
 	keepaliveTime = flags.Float64("keepalive-time", 0, prettify(`
 		If present, the maximum idle time in seconds, after which a keepalive
 		probe is sent. If the connection remains idle and no keepalive response
@@ -292,7 +299,7 @@ func main() {
 	if *connectTimeout > 0 {
 		dialTime = time.Duration(*connectTimeout * float64(time.Second))
 	}
-	ctx, cancel := context.WithTimeout(ctx, dialTime)
+	dialCtx, cancel := context.WithTimeout(ctx, dialTime)
 	defer cancel()
 	var opts []grpc.DialOption
 	if *keepaliveTime > 0 {
@@ -325,7 +332,7 @@ func main() {
 	if isUnixSocket != nil && isUnixSocket() {
 		network = "unix"
 	}
-	cc, err := grpcurl.BlockingDial(ctx, network, target, creds, opts...)
+	cc, err := dial(dialCtx, network, target, creds, *connectFailFast, opts...)
 	if err != nil {
 		fail(err, "Failed to dial target host %q", target)
 	}
@@ -717,4 +724,92 @@ func logErrorf(format string, args ...interface{}) {
 func logInfof(format string, args ...interface{}) {
 	prefix := "INFO: " + time.Now().Format("2006/01/02 15:04:05") + " "
 	log.Printf(prefix+format, args...)
+}
+
+func dial(ctx context.Context, network, addr string, creds credentials.TransportCredentials, failFast bool, opts ...grpc.DialOption) (*grpc.ClientConn, error) {
+	if failFast {
+		return grpcurl.BlockingDial(ctx, network, addr, creds, opts...)
+	}
+	// BlockingDial will return the first error returned. It is meant for interactive use.
+	// If we don't want to fail fast, then we need to do a more customized dial.
+
+	// TODO: perhaps this logic should be added to the grpcurl package, like in a new
+	// BlockingDialNoFailFast function?
+
+	dialer := &errTrackingDialer{
+		dialer:  &net.Dialer{},
+		network: network,
+	}
+	var errCreds errTrackingCreds
+	if creds == nil {
+		opts = append(opts, grpc.WithInsecure())
+	} else {
+		errCreds = errTrackingCreds{
+			TransportCredentials: creds,
+		}
+		opts = append(opts, grpc.WithTransportCredentials(&errCreds))
+	}
+
+	cc, err := grpc.DialContext(ctx, addr, append(opts, grpc.WithBlock(), grpc.WithContextDialer(dialer.dial))...)
+	if err == nil {
+		return cc, nil
+	}
+
+	// prefer last observed TLS handshake error if there is one
+	if err := errCreds.err(); err != nil {
+		return nil, err
+	}
+	// otherwise, use the error the dialer last error
+	if err := dialer.err(); err != nil {
+		return nil, err
+	}
+	// if we have no better source of error message, use what grpc.DialContext returned
+	return nil, err
+}
+
+type errTrackingCreds struct {
+	credentials.TransportCredentials
+
+	mu      sync.Mutex
+	lastErr error
+}
+
+func (c *errTrackingCreds) ClientHandshake(ctx context.Context, addr string, rawConn net.Conn) (net.Conn, credentials.AuthInfo, error) {
+	conn, auth, err := c.TransportCredentials.ClientHandshake(ctx, addr, rawConn)
+	if err != nil {
+		c.mu.Lock()
+		defer c.mu.Unlock()
+		c.lastErr = err
+	}
+	return conn, auth, err
+}
+
+func (c *errTrackingCreds) err() error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.lastErr
+}
+
+type errTrackingDialer struct {
+	dialer  *net.Dialer
+	network string
+
+	mu      sync.Mutex
+	lastErr error
+}
+
+func (c *errTrackingDialer) dial(ctx context.Context, addr string) (net.Conn, error) {
+	conn, err := c.dialer.DialContext(ctx, c.network, addr)
+	if err != nil {
+		c.mu.Lock()
+		defer c.mu.Unlock()
+		c.lastErr = err
+	}
+	return conn, err
+}
+
+func (c *errTrackingDialer) err() error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.lastErr
 }

--- a/go.mod
+++ b/go.mod
@@ -3,12 +3,12 @@ module github.com/fullstorydev/grpcui
 go 1.13
 
 require (
-	github.com/fullstorydev/grpcurl v1.8.1
+	github.com/fullstorydev/grpcurl v1.8.2
 	github.com/go-bindata/go-bindata v0.0.0-20191126083508-8639be0519b3 // indirect
 	github.com/golang/protobuf v1.4.2
 	github.com/gordonklaus/ineffassign v0.0.0-20200309095847-7953dde2c7bf // indirect
 	github.com/goreleaser/goreleaser v0.134.0 // indirect
-	github.com/jhump/protoreflect v1.8.2
+	github.com/jhump/protoreflect v1.9.0
 	github.com/nishanths/predeclared v0.0.0-20200524104333-86fad755b4d3 // indirect
 	github.com/pkg/browser v0.0.0-20180916011732-0a3d74bf9ce4
 	golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9

--- a/go.sum
+++ b/go.sum
@@ -129,6 +129,8 @@ github.com/fullstorydev/grpcurl v1.7.0 h1:GPb2O+86V4sMFBHqwZ6OJE5gtQtcqhfHYgh0Lh
 github.com/fullstorydev/grpcurl v1.7.0/go.mod h1:Mn2jWbdMrQGJQ8UD62uNyMumT2acsZUCkZIqFxsQf1o=
 github.com/fullstorydev/grpcurl v1.8.1 h1:Pp648wlTTg3OKySeqxM5pzh8XF6vLqrm8wRq66+5Xo0=
 github.com/fullstorydev/grpcurl v1.8.1/go.mod h1:3BWhvHZwNO7iLXaQlojdg5NA6SxUDePli4ecpK1N7gw=
+github.com/fullstorydev/grpcurl v1.8.2 h1:2II5e++aFnctnPJir3GL6cPSwF69Ord1u/9O+fv1vrI=
+github.com/fullstorydev/grpcurl v1.8.2/go.mod h1:YvWNT3xRp2KIRuvCphFodG0fKkMXwaxA9CJgKCcyzUQ=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/go-bindata/go-bindata v0.0.0-20191126083508-8639be0519b3 h1:vyi9feuP3xiGU/GKzmXOdHn0cLNp7RDf3bfCxk+tvno=
 github.com/go-bindata/go-bindata v0.0.0-20191126083508-8639be0519b3/go.mod h1:7xCgX1lzlrXPHkfvn3EhumqHkmSlzt8at9q7v0ax19c=
@@ -241,6 +243,8 @@ github.com/jhump/protoreflect v1.6.1 h1:4/2yi5LyDPP7nN+Hiird1SAJ6YoxUm13/oxHGRnb
 github.com/jhump/protoreflect v1.6.1/go.mod h1:RZQ/lnuN+zqeRVpQigTwO6o0AJUkxbnSnpuG7toUTG4=
 github.com/jhump/protoreflect v1.8.2 h1:k2xE7wcUomeqwY0LDCYA16y4WWfyTcMx5mKhk0d4ua0=
 github.com/jhump/protoreflect v1.8.2/go.mod h1:7GcYQDdMU/O/BBrl/cX6PNHpXh6cenjd8pneu5yW7Tg=
+github.com/jhump/protoreflect v1.9.0 h1:npqHz788dryJiR/l6K/RUQAyh2SwV91+d1dnh4RjO9w=
+github.com/jhump/protoreflect v1.9.0/go.mod h1:7GcYQDdMU/O/BBrl/cX6PNHpXh6cenjd8pneu5yW7Tg=
 github.com/jmespath/go-jmespath v0.0.0-20160202185014-0b12d6b521d8/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=
 github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af h1:pmfjZENx5imkbgOkpRUYLnmbU7UEFbjtDA2hxJ1ichM=
 github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=


### PR DESCRIPTION
Fixes #101.

I had originally hoped to address this with changes in the underlying `grpcurl.BlockingDial` function. And I even submitted a change to that function. However, after trying it out, I discovered that the change did not actually work -- there are other issues with `BlockingDial` that cause it to fail fast, and they are not easy to resolve, especially in a backwards-compatible way.

So I instead had to fork the dialing logic since what we want here is just completely different from `BlockingDial` -- it is very much focused on the interactive use case, and has several places that cause it to intentionally fail-fast (with as good of an error message as possible, since the error returned from `grpc.DialContext` can be bad and can obscure underlying connection error messages).

So this adds a new flag to `grpcui` so users can do `-connect-fail-fast=false`. In this mode, it does not use `grpcurl.BlockingDial` at all. Instead it uses its own dial logic that intentionally never fails fast, so it will rely on the underlying `grpc.Dial` capability to perform retries and backoff. It still does some decoration around the call to `grpc.Dial`, just to get the best error message possible (since, as mentioned above, the gRPC runtime can return bad error messages).

The first commit is not strictly necessary. That was when I was trying out the changes to `grpcurl.BlockingDial`, before realizing they were inadequate. But I left the commit here since it seems reasonable to be up-to-date with the latest releases for these dependencies.