### PR TITLE
Cap of input timeout at MaxInt64

### DIFF
--- a/handlers.go
+++ b/handlers.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
+	"math"
 	"net/http"
 	"sort"
 	"strconv"
@@ -402,6 +403,10 @@ func invokeRPC(ctx context.Context, methodName string, ch grpcdynamic.Channel, d
 	if input.TimeoutSeconds > 0 {
 		var cancel context.CancelFunc
 		timeout := time.Duration(input.TimeoutSeconds * float32(time.Second))
+		// If the timeout is too huge that it overflows int64, cap it off.
+		if timeout < 0 {
+			timeout = time.Duration(math.MaxInt64)
+		}
 		ctx, cancel = context.WithTimeout(ctx, timeout)
 		defer cancel()
 	}


### PR DESCRIPTION
Since we're not validating inputs, users can provide an absurdly large timeout. This can overflow an int64 when it is converted to nanoseconds. So cap off the value at `math.MaxInt64`.
