### PR TITLE
reconcile grpcui cmd-line options with grpcurl

### DIFF
--- a/cmd/grpcui/grpcui.go
+++ b/cmd/grpcui/grpcui.go
@@ -6,10 +6,12 @@ package main
 
 import (
 	"bytes"
+	"encoding/hex"
 	"flag"
 	"fmt"
+	"io"
 	"io/ioutil"
-	"log"
+	"mime"
 	"net"
 	"net/http"
 	"net/http/httptest"
@@ -40,6 +42,7 @@ import (
 	// Register xds so xds and xds-experimental resolver schemes work
 	_ "google.golang.org/grpc/xds"
 
+	"github.com/fullstorydev/grpcui/internal"
 	"github.com/fullstorydev/grpcui/standalone"
 )
 
@@ -70,12 +73,24 @@ var (
 	key = flags.String("key", "", prettify(`
 		File containing client private key, to present to the server. Not valid
 		with -plaintext option. Must also provide -cert option.`))
-	protoset    multiString
-	protoFiles  multiString
-	importPaths multiString
-	reflHeaders multiString
-	defHeaders  multiString
-	authority   = flags.String("authority", "", prettify(`
+	protoset      multiString
+	protoFiles    multiString
+	importPaths   multiString
+	addlHeaders   multiString
+	rpcHeaders    multiString
+	reflHeaders   multiString
+	prsvHeaders   multiString
+	defHeaders    multiString
+	expandHeaders = flags.Bool("expand-headers", false, prettify(`
+		If set, headers may use '${NAME}' syntax to reference environment
+		variables. These will be expanded to the actual environment variable
+		value before sending to the server. For example, if there is an
+		environment variable defined like FOO=bar, then a header of
+		'key: ${FOO}' would expand to 'key: bar'. This applies to -H,
+		-rpc-header, -reflect-header, and -default-header options. No other
+		expansion/escaping is performed. This can be used to supply
+		credentials/secrets without having to put them in command-line arguments.`))
+	authority = flags.String("authority", "", prettify(`
 		The authoritative name of the remote server. This value is passed as the
 		value of the ":authority" pseudo-header in the HTTP/2 protocol. When TLS
 		is used, this will also be used as the server name when verifying the
@@ -121,6 +136,7 @@ var (
 		This defaults to true when grpcui is used in an interactive mode; e.g.
 		when the tool detects that stdin is a terminal/tty. Otherwise, this
 		defaults to false.`))
+	reflection = optionalBoolFlag{val: true}
 
 	port = flags.Int("port", 0, prettify(`
 		The port on which the web UI is exposed.`))
@@ -135,11 +151,35 @@ var (
 )
 
 func init() {
+	flags.Var(&addlHeaders, "H", prettify(`
+		Additional headers in 'name: value' format. May specify more than one
+		via multiple flags. These headers will also be included in reflection
+		requests to a server. These headers are not shown in the gRPC UI form.
+		If the user enters conflicting metadata, the user-entered value will be
+		ignored and only the values present on the command-line will be used.`))
+	flags.Var(&rpcHeaders, "rpc-header", prettify(`
+		Additional RPC headers in 'name: value' format. May specify more than
+		one via multiple flags. These headers will *only* be used when invoking
+		the requested RPC method. They are excluded from reflection requests.
+		These headers are not shown in the gRPC UI form. If the user enters
+		conflicting metadata, the user-entered value will be ignored and only
+		the values present on the command-line will be used.`))
 	flags.Var(&reflHeaders, "reflect-header", prettify(`
 		Additional reflection headers in 'name: value' format. May specify more
 		than one via multiple flags. These headers will only be used during
 		reflection requests and will be excluded when invoking the requested RPC
 		method.`))
+	flags.Var(&prsvHeaders, "preserve-header", prettify(`
+		Header names (no values) for request headers that should be preserved
+		when making requests to the gRPC server. May specify more than one via
+		multiple flags. In addition to the headers given in -H and -rpc-header
+		flags and metadata defined in the gRPC UI form, the gRPC server will also
+		get any of the named headers that the gRPC UI web server receives as HTTP
+		request headers. This can be useful if gRPC UI is behind an
+		authenticating proxy, for example, that adds JWTs to HTTP requests.
+		Having gRPC UI preserve these headers means that the JWTs will also be
+		sent to backend gRPC servers. These headers are only sent when RPCs are
+		invoked and are not included for reflection requests.`))
 	flags.Var(&defHeaders, "default-header", prettify(`
 		Additional headers to add to metadata in the gRPCui web form. Each value
 		should be in 'name: value' format. May specify more than one via multiple
@@ -185,6 +225,12 @@ func init() {
 	flags.Var(&debug, "debug-client", prettify(`
 		When true, the client JS code in the gRPCui web form will log extra
 		debug info to the console.`))
+	flags.Var(&reflection, "use-reflection", prettify(`
+		When true, server reflection will be used to determine the RPC schema.
+		Defaults to true unless a -proto or -protoset option is provided. If
+		-use-reflection is used in combination with a -proto or -protoset flag,
+		the provided descriptor sources will be used in addition to server
+		reflection to resolve messages and extensions.`))
 }
 
 type multiString []string
@@ -221,6 +267,49 @@ func (f *optionalBoolFlag) Set(s string) error {
 
 func (f *optionalBoolFlag) IsBoolFlag() bool {
 	return true
+}
+
+// Uses a file source as a fallback for resolving symbols and extensions, but
+// only uses the reflection source for listing services
+type compositeSource struct {
+	reflection grpcurl.DescriptorSource
+	file       grpcurl.DescriptorSource
+}
+
+func (cs compositeSource) ListServices() ([]string, error) {
+	return cs.reflection.ListServices()
+}
+
+func (cs compositeSource) FindSymbol(fullyQualifiedName string) (desc.Descriptor, error) {
+	d, err := cs.reflection.FindSymbol(fullyQualifiedName)
+	if err == nil {
+		return d, nil
+	}
+	return cs.file.FindSymbol(fullyQualifiedName)
+}
+
+func (cs compositeSource) AllExtensionsForType(typeName string) ([]*desc.FieldDescriptor, error) {
+	exts, err := cs.reflection.AllExtensionsForType(typeName)
+	if err != nil {
+		// On error fall back to file source
+		return cs.file.AllExtensionsForType(typeName)
+	}
+	// Track the tag numbers from the reflection source
+	tags := make(map[int32]bool)
+	for _, ext := range exts {
+		tags[ext.GetNumber()] = true
+	}
+	fileExts, err := cs.file.AllExtensionsForType(typeName)
+	if err != nil {
+		return exts, nil
+	}
+	for _, ext := range fileExts {
+		// Prioritize extensions found via reflection
+		if !tags[ext.GetNumber()] {
+			exts = append(exts, ext)
+		}
+	}
+	return exts, nil
 }
 
 func main() {
@@ -280,8 +369,16 @@ func main() {
 	if len(importPaths) > 0 && len(protoFiles) == 0 {
 		warn("The -import-path argument is not used unless -proto files are used.")
 	}
+	if !reflection.val && len(protoset) == 0 && len(protoFiles) == 0 {
+		fail(nil, "No protoset files or proto files specified and -use-reflection set to false.")
+	}
 	if !strings.HasPrefix(*basePath, "/") {
 		fail(nil, `The -base-path must begin with a slash ("/")`)
+	}
+
+	// Protoset or protofiles provided and -use-reflection unset
+	if !reflection.set && (len(protoset) > 0 || len(protoFiles) > 0) {
+		reflection.val = false
 	}
 
 	configs, err := computeSvcConfigs()
@@ -289,25 +386,27 @@ func main() {
 		fail(err, "Invalid services/methods indicated")
 	}
 
-	if *veryVeryVerbose {
-		// very-very verbose implies very verbose
-		*veryVerbose = true
+	var verbosity int
+	switch {
+	case *veryVeryVerbose:
+		verbosity = 3
+	case *veryVerbose:
+		verbosity = 2
+	case *verbose:
+		verbosity = 1
 	}
 
-	if *verbose && !*veryVerbose {
+	if verbosity == 1 {
 		// verbose will let grpc package print warnings and errors
 		grpclog.SetLoggerV2(grpclog.NewLoggerV2(ioutil.Discard, os.Stdout, ioutil.Discard))
-	} else if *veryVerbose {
-		// very verbose implies verbose
-		*verbose = true
-
+	} else if verbosity > 1 {
 		// very verbose will let grpc package log info
 		// and very very verbose turns up the verbosity
-		v := 0
-		if *veryVeryVerbose {
-			v = 5
+		grpcVerbosity := 0
+		if verbosity > 2 {
+			grpcVerbosity = 5
 		}
-		grpclog.SetLoggerV2(grpclog.NewLoggerV2WithVerbosity(os.Stdout, ioutil.Discard, ioutil.Discard, v))
+		grpclog.SetLoggerV2(grpclog.NewLoggerV2WithVerbosity(os.Stdout, ioutil.Discard, ioutil.Discard, grpcVerbosity))
 	}
 
 	ctx := context.Background()
@@ -328,6 +427,27 @@ func main() {
 	if *maxMsgSz > 0 {
 		opts = append(opts, grpc.WithDefaultCallOptions(grpc.MaxCallRecvMsgSize(*maxMsgSz)))
 	}
+
+	if *expandHeaders {
+		var err error
+		addlHeaders, err = grpcurl.ExpandHeaders(addlHeaders)
+		if err != nil {
+			fail(err, "Failed to expand additional headers")
+		}
+		rpcHeaders, err = grpcurl.ExpandHeaders(rpcHeaders)
+		if err != nil {
+			fail(err, "Failed to expand rpc headers")
+		}
+		reflHeaders, err = grpcurl.ExpandHeaders(reflHeaders)
+		if err != nil {
+			fail(err, "Failed to expand reflection headers")
+		}
+		defHeaders, err = grpcurl.ExpandHeaders(defHeaders)
+		if err != nil {
+			fail(err, "Failed to expand default headers")
+		}
+	}
+
 	var creds credentials.TransportCredentials
 	if !*plaintext {
 		tlsConf, err := grpcurl.ClientTLSConfig(*insecure, *cacert, *cert, *key)
@@ -366,23 +486,32 @@ func main() {
 
 	var descSource grpcurl.DescriptorSource
 	var refClient *grpcreflect.Client
+	var fileSource grpcurl.DescriptorSource
 	if len(protoset) > 0 {
 		var err error
-		descSource, err = grpcurl.DescriptorSourceFromProtoSets(protoset...)
+		fileSource, err = grpcurl.DescriptorSourceFromProtoSets(protoset...)
 		if err != nil {
 			fail(err, "Failed to process proto descriptor sets.")
 		}
 	} else if len(protoFiles) > 0 {
 		var err error
-		descSource, err = grpcurl.DescriptorSourceFromProtoFiles(importPaths, protoFiles...)
+		fileSource, err = grpcurl.DescriptorSourceFromProtoFiles(importPaths, protoFiles...)
 		if err != nil {
 			fail(err, "Failed to process proto source files.")
 		}
-	} else {
+	}
+	if reflection.val {
 		md := grpcurl.MetadataFromHeaders(reflHeaders)
 		refCtx := metadata.NewOutgoingContext(ctx, md)
 		refClient = grpcreflect.NewClient(refCtx, reflectpb.NewServerReflectionClient(cc))
-		descSource = grpcurl.DescriptorSourceFromServer(ctx, refClient)
+		reflSource := grpcurl.DescriptorSourceFromServer(ctx, refClient)
+		if fileSource != nil {
+			descSource = compositeSource{reflSource, fileSource}
+		} else {
+			descSource = reflSource
+		}
+	} else {
+		descSource = fileSource
 	}
 
 	// arrange for the RPCs to be cleanly shutdown
@@ -422,8 +551,17 @@ func main() {
 	if len(defHeaders) > 0 {
 		handlerOpts = append(handlerOpts, standalone.WithDefaultMetadata(defHeaders))
 	}
+	if len(addlHeaders) > 0 || len(rpcHeaders) > 0 {
+		handlerOpts = append(handlerOpts, standalone.WithMetadata(append(addlHeaders, rpcHeaders...)))
+	}
+	if len(prsvHeaders) > 0 {
+		handlerOpts = append(handlerOpts, standalone.PreserveHeaders(prsvHeaders))
+	}
+	if verbosity > 0 {
+		handlerOpts = append(handlerOpts, standalone.WithInvokeVerbosity(verbosity))
+	}
 	if debug.set {
-		handlerOpts = append(handlerOpts, standalone.WithDebug(debug.val))
+		handlerOpts = append(handlerOpts, standalone.WithClientDebug(debug.val))
 	}
 	handler := standalone.Handler(cc, target, methods, allFiles, handlerOpts...)
 	if *maxTime > 0 {
@@ -441,20 +579,23 @@ func main() {
 		})
 	}
 
-	if *verbose {
+	if verbosity > 0 {
 		// wrap the handler with one that performs more logging of what's going on
 		orig := handler
 		handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			start := time.Now()
 
-			if *veryVerbose {
-				if req, err := httputil.DumpRequest(r, *veryVeryVerbose); err != nil {
-					logErrorf("could not dump request: %v", err)
+			if verbosity > 1 {
+				// TODO: the web form never sends binary request body; but maybe a custom
+				//  JS addition could, so maybe this should be a custom printer of the request
+				//  like we have for the response below?
+				if req, err := httputil.DumpRequest(r, verbosity > 2); err != nil {
+					internal.LogErrorf("could not dump request: %v", err)
 				} else {
-					logInfof("received request:\n%s", string(req))
+					internal.LogInfof("received request:\n%s", string(req))
 				}
 				var recorder httptest.ResponseRecorder
-				if *veryVeryVerbose {
+				if verbosity > 2 {
 					recorder.Body = &bytes.Buffer{}
 				}
 				tee := teeWriter{w: []http.ResponseWriter{w, &recorder}}
@@ -463,10 +604,10 @@ func main() {
 					// in case handler never called Write or WriteHeader:
 					tee.mirrorHeaders()
 
-					if resp, err := httputil.DumpResponse(recorder.Result(), *veryVeryVerbose); err != nil {
-						logErrorf("could not dump response: %v", err)
+					if resp, err := dumpResponse(recorder.Result(), verbosity > 2); err != nil {
+						internal.LogErrorf("could not dump response: %v", err)
 					} else {
-						logInfof("sent response:\n%s", string(resp))
+						internal.LogInfof("sent response:\n%s", resp)
 					}
 				}()
 			}
@@ -475,7 +616,7 @@ func main() {
 			orig.ServeHTTP(&cs, r)
 
 			millis := time.Since(start).Nanoseconds() / (1000 * 1000)
-			logInfof("%s %s %s %d %dms %dbytes", r.RemoteAddr, r.Method, r.RequestURI, cs.code, millis, cs.size)
+			internal.LogInfof("%s %s %s %d %dms %dbytes", r.RemoteAddr, r.Method, r.RequestURI, cs.code, millis, cs.size)
 		})
 	}
 	if *basePath != "/" {
@@ -754,16 +895,6 @@ func (cs *codeSniffer) WriteHeader(statusCode int) {
 	cs.w.WriteHeader(statusCode)
 }
 
-func logErrorf(format string, args ...interface{}) {
-	prefix := "ERROR: " + time.Now().Format("2006/01/02 15:04:05") + " "
-	log.Printf(prefix+format, args...)
-}
-
-func logInfof(format string, args ...interface{}) {
-	prefix := "INFO: " + time.Now().Format("2006/01/02 15:04:05") + " "
-	log.Printf(prefix+format, args...)
-}
-
 func dial(ctx context.Context, network, addr string, creds credentials.TransportCredentials, failFast bool, opts ...grpc.DialOption) (*grpc.ClientConn, error) {
 	if failFast {
 		return grpcurl.BlockingDial(ctx, network, addr, creds, opts...)
@@ -850,4 +981,62 @@ func (c *errTrackingDialer) err() error {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	return c.lastErr
+}
+
+func dumpResponse(r *http.Response, includeBody bool) (string, error) {
+	// NB: not using httputil.DumpResponse because it writes binary data in the body which is
+	//  not useful in the log (and can cause unexpected behavior when writing to a terminal,
+	//  which may interpret some byte sequences as control codes).
+	var buf bytes.Buffer
+	buf.WriteString(r.Status)
+	buf.WriteRune('\n')
+	if err := r.Header.Write(&buf); err != nil {
+		return "", err
+	}
+	if includeBody {
+		buf.WriteRune('\n')
+		ct := strings.ToLower(r.Header.Get("content-type"))
+		mt, _, err := mime.ParseMediaType(ct)
+		if err != nil {
+			mt = ct
+		}
+		isText := strings.HasPrefix(mt, "text/") ||
+			mt == "application/json" ||
+			mt == "application/javascript" ||
+			mt == "application/x-www-form-urlencoded" ||
+			mt == "multipart/form-data" ||
+			mt == "application/xml"
+		if isText {
+			if _, err := io.Copy(&buf, r.Body); err != nil {
+				return "", err
+			}
+		} else {
+			first := true
+			var block [32]byte
+			for {
+				n, err := r.Body.Read(block[:])
+				if n > 0 {
+					if first {
+						buf.WriteString("(binary body; encoded in hex)\n")
+						first = false
+					}
+					for i := 0; i < n; i += 8 {
+						end := i + 8
+						if end > n {
+							end = n
+						}
+						buf.WriteString(hex.EncodeToString(block[i:end]))
+						buf.WriteRune(' ')
+					}
+					buf.WriteRune('\n')
+				}
+				if err == io.EOF {
+					break
+				} else if err != nil {
+					return "", err
+				}
+			}
+		}
+	}
+	return buf.String(), nil
 }

--- a/handlers.go
+++ b/handlers.go
@@ -19,11 +19,12 @@ import (
 	"github.com/golang/protobuf/proto"  //lint:ignore SA1019 we have to import this because it appears in grpcurl APIs used herein
 	"github.com/golang/protobuf/protoc-gen-go/descriptor"
 	"github.com/jhump/protoreflect/desc"
-	"github.com/jhump/protoreflect/dynamic/grpcdynamic"
+	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
 
+	"github.com/fullstorydev/grpcui/internal"
 	"github.com/fullstorydev/grpcurl"
 )
 
@@ -41,7 +42,35 @@ import (
 // Note that the returned handler does not implement any CSRF protection. To
 // provide that, you will need to wrap the returned handler with one that first
 // enforces CSRF checks.
-func RPCInvokeHandler(ch grpcdynamic.Channel, descs []*desc.MethodDescriptor) http.Handler {
+func RPCInvokeHandler(ch grpc.ClientConnInterface, descs []*desc.MethodDescriptor) http.Handler {
+	return RPCInvokeHandlerWithOptions(ch, descs, InvokeOptions{})
+}
+
+// InvokeOptions contains optional arguments when creating a gRPCui invocation
+// handler.
+type InvokeOptions struct {
+	// The set of metadata to add to all outgoing RPCs. If the invocation
+	// request includes conflicting metadata, these values override, and the
+	// values in the request will not be sent.
+	ExtraMetadata []string
+	// The set of HTTP header names that will be preserved. These are HTTP
+	// request headers included in the invocation request that will be added as
+	// request metadata when invoking the RPC. If the invocation request
+	// includes conflicting metadata, the values in the HTTP request headers
+	// will override, and the values in the request will not be sent.
+	PreserveHeaders []string
+	// If verbosity is greater than zero, the handler may log events, such as
+	// cases where the request included metadata that conflicts with the
+	// ExtraMetadata and PreserveHeaders fields above. It is an int, instead
+	// of a bool "verbose" flag, so that additional logs may be added in the
+	// future and the caller control how detailed those logs will be.
+	Verbosity int
+}
+
+// RPCInvokeHandlerWithOptions is the same as RPCInvokeHandler except that it
+// accepts an additional argument, options. This can be used to add extra
+// request metadata to all RPCs invoked.
+func RPCInvokeHandlerWithOptions(ch grpc.ClientConnInterface, descs []*desc.MethodDescriptor, options InvokeOptions) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != "POST" {
 			w.Header().Set("Allow", "POST")
@@ -66,7 +95,7 @@ func RPCInvokeHandler(ch grpcdynamic.Channel, descs []*desc.MethodDescriptor) ht
 					http.Error(w, "Failed to create descriptor source: "+err.Error(), http.StatusInternalServerError)
 					return
 				}
-				results, err := invokeRPC(r.Context(), method, ch, descSource, r.Body)
+				results, err := invokeRPC(r.Context(), method, ch, descSource, r.Header, r.Body, &options)
 				if err != nil {
 					if _, ok := err.(errReadFail); ok {
 						http.Error(w, "Failed to read request", 499)
@@ -368,7 +397,7 @@ func (e errReadFail) Error() string {
 	return e.err.Error()
 }
 
-func invokeRPC(ctx context.Context, methodName string, ch grpcdynamic.Channel, descSource grpcurl.DescriptorSource, body io.Reader) (*rpcResult, error) {
+func invokeRPC(ctx context.Context, methodName string, ch grpc.ClientConnInterface, descSource grpcurl.DescriptorSource, reqHdrs http.Header, body io.Reader, options *InvokeOptions) (*rpcResult, error) {
 	js, err := ioutil.ReadAll(body)
 	if err != nil {
 		return nil, errReadFail{err: err}
@@ -389,16 +418,17 @@ func invokeRPC(ctx context.Context, methodName string, ch grpcdynamic.Channel, d
 		reqStats.Sent++
 		req := input.Data[0]
 		input.Data = input.Data[1:]
-		if err := jsonpb.Unmarshal(bytes.NewReader([]byte(req)), m); err != nil {
+		if err := jsonpb.Unmarshal(bytes.NewReader(req), m); err != nil {
 			return status.Errorf(codes.InvalidArgument, err.Error())
 		}
 		return nil
 	}
 
-	hdrs := make([]string, len(input.Metadata))
-	for i, hdr := range input.Metadata {
-		hdrs[i] = fmt.Sprintf("%s: %s", hdr.Name, hdr.Value)
+	webFormHdrs := make(metadata.MD, len(input.Metadata))
+	for _, hdr := range input.Metadata {
+		webFormHdrs.Append(hdr.Name, hdr.Value)
 	}
+	invokeHdrs := options.computeHeaders(reqHdrs, webFormHdrs)
 
 	if input.TimeoutSeconds > 0 {
 		var cancel context.CancelFunc
@@ -415,11 +445,54 @@ func invokeRPC(ctx context.Context, methodName string, ch grpcdynamic.Channel, d
 		descSource: descSource,
 		Requests:   &reqStats,
 	}
-	if err := grpcurl.InvokeRPC(ctx, descSource, ch, methodName, hdrs, &result, requestFunc); err != nil {
+	if err := grpcurl.InvokeRPC(ctx, descSource, ch, methodName, invokeHdrs, &result, requestFunc); err != nil {
 		return nil, err
 	}
 
 	return &result, nil
+}
+
+func (opts *InvokeOptions) overrideHeaders(reqHdrs http.Header) metadata.MD {
+	hdrs := grpcurl.MetadataFromHeaders(opts.ExtraMetadata)
+	for _, name := range opts.PreserveHeaders {
+		vals := reqHdrs.Values(name)
+		if opts.Verbosity > 0 {
+			if existing := hdrs.Get(name); len(existing) > 0 {
+				internal.LogInfof("preserving HTTP header %q, which overrides given extra header", name)
+			}
+		}
+		hdrs.Set(name, vals...)
+	}
+	return hdrs
+}
+
+func (opts *InvokeOptions) computeHeaders(reqHdrs http.Header, webFormHdrs metadata.MD) []string {
+	// add extra headers, overriding whatever was in the web form
+	overrideHdrs := opts.overrideHeaders(reqHdrs)
+	for k, v := range overrideHdrs {
+		if opts.Verbosity > 0 {
+			if existing := webFormHdrs.Get(k); len(existing) > 0 {
+				internal.LogInfof("web form included metadata %q, but it will be ignored due to given extra/preserved headers", k)
+			}
+		}
+		webFormHdrs[k] = v
+	}
+
+	// convert them back to the form that the grpcurl lib expects
+	totalLen := 0
+	keys := make([]string, 0, len(webFormHdrs))
+	for k, vs := range webFormHdrs {
+		totalLen += len(vs)
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	result := make([]string, 0, totalLen)
+	for _, k := range keys {
+		for _, v := range webFormHdrs[k] {
+			result = append(result, fmt.Sprintf("%s: %s", k, v))
+		}
+	}
+	return result
 }
 
 type rpcMetadata struct {

--- a/internal/log.go
+++ b/internal/log.go
@@ -1,0 +1,16 @@
+package internal
+
+import (
+	"log"
+	"time"
+)
+
+func LogErrorf(format string, args ...interface{}) {
+	prefix := "ERROR: " + time.Now().Format("2006/01/02 15:04:05") + " "
+	log.Printf(prefix+format, args...)
+}
+
+func LogInfof(format string, args ...interface{}) {
+	prefix := "INFO: " + time.Now().Format("2006/01/02 15:04:05") + " "
+	log.Printf(prefix+format, args...)
+}

--- a/standalone/opts.go
+++ b/standalone/opts.go
@@ -68,7 +68,7 @@ func AddCSS(filename string, css []byte) HandlerOption {
 	})
 }
 
-// ServeAsset will add an additional file to Hadler, serving the supplied contents
+// ServeAsset will add an additional file to Handler, serving the supplied contents
 // at the URI "/s/<filename>" with a Content-Type that is computed based on the given
 // filename's extension.
 //
@@ -89,9 +89,46 @@ func WithDefaultMetadata(headers []string) HandlerOption {
 	})
 }
 
+// WithMetadata adds extra request metadata that will be included when an RPC
+// in invoked. Each string should be in the form "name: value". If the web
+// form includes conflicting metadata, the web form input will be ignored and
+// the metadata supplied to this option will be sent instead.
+func WithMetadata(headers []string) HandlerOption {
+	return optFunc(func(opts *handlerOptions) {
+		opts.extraMetadata = headers
+	})
+}
+
+// PreserveHeaders instructs the Handler to preserve the named HTTP headers
+// if they are included in the invocation request, and send them as request
+// metadata when invoking the RPC. If the web form includes conflicting
+// metadata, the web form input will be ignored and the matching header
+// value in the HTTP request will be sent instead.
+func PreserveHeaders(headerNames []string) HandlerOption {
+	return optFunc(func(opts *handlerOptions) {
+		opts.preserveHeaders = headerNames
+	})
+}
+
+// WithInvokeVerbosity indicates the level of log output from the gRPC UI server
+// handler that performs RPC invocations.
+func WithInvokeVerbosity(verbosity int) HandlerOption {
+	return optFunc(func(opts *handlerOptions) {
+		opts.invokeVerbosity = verbosity
+	})
+}
+
 // WithDebug enables console logging in the client JS. This prints extra
 // information as the UI processes user input.
+//
+// Deprecated: Use WithClientDebug instead.
 func WithDebug(debug bool) HandlerOption {
+	return WithClientDebug(debug)
+}
+
+// WithClientDebug enables console logging in the client JS. This prints extra
+// information as the UI processes user input.
+func WithClientDebug(debug bool) HandlerOption {
 	return optFunc(func(opts *handlerOptions) {
 		opts.debug = &debug
 	})
@@ -111,6 +148,9 @@ type handlerOptions struct {
 	tmplResources       []*resource
 	servedOnlyResources []*resource
 	defaultMetadata     []string
+	extraMetadata       []string
+	preserveHeaders     []string
+	invokeVerbosity     int
 	debug               *bool
 }
 

--- a/standalone/standalone.go
+++ b/standalone/standalone.go
@@ -85,7 +85,12 @@ func Handler(ch grpcdynamic.Channel, target string, methods []*desc.MethodDescri
 		}
 	})
 
-	rpcInvokeHandler := http.StripPrefix("/invoke", grpcui.RPCInvokeHandler(ch, methods))
+	invokeOpts := grpcui.InvokeOptions{
+		ExtraMetadata:   uiOpts.extraMetadata,
+		PreserveHeaders: uiOpts.preserveHeaders,
+		Verbosity:       uiOpts.invokeVerbosity,
+	}
+	rpcInvokeHandler := http.StripPrefix("/invoke", grpcui.RPCInvokeHandlerWithOptions(ch, methods, invokeOpts))
 	mux.HandleFunc("/invoke/", func(w http.ResponseWriter, r *http.Request) {
 		// CSRF protection
 		c, _ := r.Cookie(csrfCookieName)

--- a/webform.go
+++ b/webform.go
@@ -62,8 +62,8 @@ type WebFormOptions struct {
 	Debug *bool
 }
 
-// WebFormContentsWithDefaultMetadata is the same as WebFormContents except that
-// it accepts an additional argument, options. This can be used to toggle the JS
+// WebFormContentsWithOptions is the same as WebFormContents except that it
+// accepts an additional argument, options. This can be used to toggle the JS
 // code into debug logging and can also be used to define the set of metadata to
 // show in the web form by default (empty if unspecified).
 func WebFormContentsWithOptions(invokeURI, metadataURI string, descs []*desc.MethodDescriptor, opts WebFormOptions) []byte {


### PR DESCRIPTION
This adds several command-line options to `grpcui` that are already available in `grpcurl`:
* `-H`, `-rpc-header`: These allow adding extra metadata to all requests, _in addition to_ what the user enters in the web form UI. The difference is that `-H` headers will _also_ be added to reflection requests.
*  `-expand-headers`: This allows for safe use of secrets in metadata by putting them in environment variables instead of on the command-line
* `-use-reflection`: This allows using both server reflection _and_ proto sources, which can be useful to add extra descriptors that the server may not know about for resolving extensions and `google.protobuf.Any` messages.

This also adds a new, related option:
* `-preserve-header`: This allows for propagating headers from the invocation request (which could include headers added by a client/browser/user agent as well as proxies in between the client and the grpcui server) to request metadata on the invoked RPC.

Finally, this PR _fixes_ the HTTP response output when using the `-vvv` "very very verbose" log output. Before this change, binary data is written to the output as raw bytes. When the output is a terminal, this can cause undesirable behavior since some sequences of raw bytes may be interpreted as control/escape sequences. Now, binary output for HTTP responses is encoded in hex.

Fixes #111 and #126.
This should also help with #99.