### PR TITLE
fix: add -H headers argument to reflection request

### DIFF
--- a/cmd/grpcui/grpcui.go
+++ b/cmd/grpcui/grpcui.go
@@ -561,7 +561,7 @@ func main() {
 		}
 	}
 	if reflection.val {
-		md := grpcurl.MetadataFromHeaders(append(addlHeaders, reflHeaders))
+		md := grpcurl.MetadataFromHeaders(append(addlHeaders, reflHeaders...))
 		refCtx := metadata.NewOutgoingContext(ctx, md)
 		refClient = grpcreflect.NewClient(refCtx, reflectpb.NewServerReflectionClient(cc))
 		reflSource := grpcurl.DescriptorSourceFromServer(ctx, refClient)

--- a/cmd/grpcui/grpcui.go
+++ b/cmd/grpcui/grpcui.go
@@ -561,7 +561,7 @@ func main() {
 		}
 	}
 	if reflection.val {
-		md := grpcurl.MetadataFromHeaders(reflHeaders)
+		md := grpcurl.MetadataFromHeaders(append(addlHeaders, reflHeaders))
 		refCtx := metadata.NewOutgoingContext(ctx, md)
 		refClient = grpcreflect.NewClient(refCtx, reflectpb.NewServerReflectionClient(cc))
 		reflSource := grpcurl.DescriptorSourceFromServer(ctx, refClient)


### PR DESCRIPTION
The documentation describe the `-H` option as 

> ...These headers will also be included in reflection requests to a server....

This PR make sure they are passed to the RPC reflection call