### PR TITLE
Add a "Now" button for timestamp

### DIFF
--- a/internal/resources/webform/webform-sample.css
+++ b/internal/resources/webform/webform-sample.css
@@ -406,8 +406,8 @@ table#grpc-request-metadata-form {
 
 #grpc-request-form div.input_container button {
     padding: 2px 4px;
-	border-radius: 3px;
-	font-size: 12px;
+    border-radius: 3px;
+    font-size: 12px;
 }
 
 #grpc-form .grpc-request-table button {

--- a/internal/resources/webform/webform-sample.css
+++ b/internal/resources/webform/webform-sample.css
@@ -404,6 +404,12 @@ table#grpc-request-metadata-form {
     border: 1px solid #ddd;
 }
 
+#grpc-request-form div.input_container button {
+    padding: 2px 4px;
+	border-radius: 3px;
+	font-size: 12px;
+}
+
 #grpc-form .grpc-request-table button {
     padding: 2px 4px;
     border-radius: 3px;

--- a/internal/resources/webform/webform.js
+++ b/internal/resources/webform/webform.js
@@ -1558,7 +1558,7 @@ window.initGRPCForm = function(services, svcDescs, mtdDescs, invokeURI, metadata
         time.attr('size', 20);
         time.attr('value', "" + parts[1]);
         div.append(time);
-        
+
         var setNow = $('<button>Now</button>');
         div.append(setNow);
         container.append(div);
@@ -1619,9 +1619,9 @@ window.initGRPCForm = function(services, svcDescs, mtdDescs, invokeURI, metadata
                                 $('#ui-datepicker-div').addClass('grpc-timestamp-picker');
                             },
                         });
-        
+
         setNow.click(function() {
-            var now = (new Date()).toUTCString();
+            var now = (new Date()).toISOString();
             var nowSplit = now.split('T', 2);
             date.val(nowSplit[0]);
             time.val(nowSplit[1]);

--- a/internal/resources/webform/webform.js
+++ b/internal/resources/webform/webform.js
@@ -1558,6 +1558,9 @@ window.initGRPCForm = function(services, svcDescs, mtdDescs, invokeURI, metadata
         time.attr('size', 20);
         time.attr('value', "" + parts[1]);
         div.append(time);
+        
+        var setNow = $('<button>Now</button>');
+        div.append(setNow);
         container.append(div);
 
         var input = new Input(parent, [], value);
@@ -1616,6 +1619,14 @@ window.initGRPCForm = function(services, svcDescs, mtdDescs, invokeURI, metadata
                                 $('#ui-datepicker-div').addClass('grpc-timestamp-picker');
                             },
                         });
+        
+        setNow.click(function() {
+            var now = (new Date()).toUTCString();
+            var nowSplit = now.split('T', 2);
+            date.val(nowSplit[0]);
+            time.val(nowSplit[1]);
+            input.setValue(now);
+        });
         return input;
     }
 


### PR DESCRIPTION
I often want to set a timestamp field to the current time, and have to do that manually.

This PR adds a button next to the `google.protobuf.Timestamp` fields to set the timestamp to the current UTC time (based on the browser's time).