### PR TITLE
Don't try to open browser when running in Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,4 +27,4 @@ COPY --from=builder /grpcui /bin/grpcui
 USER grpcui
 EXPOSE 8080
 
-ENTRYPOINT ["/bin/grpcui", "-bind=0.0.0.0", "-port=8080"]
+ENTRYPOINT ["/bin/grpcui", "-bind=0.0.0.0", "-port=8080", "-open-browser=false"]


### PR DESCRIPTION
If I use the `-it` flags with `docker run`, the tool realizes it's in interactive mode, so it tries to open a browser. But that doesn't work from inside a container.

Here's the error I see:
```
Failed to open browser: exec: "xdg-open": executable file not found in $PATH
```

It's not a fatal error, so the tool still works. It's just a nuisance error in the output. This one-liner should remedy that.