### PR TITLE
Add installation instruction for homebrew

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,12 @@ the form of an HTML table.
 
 ## Installation
 
+### Homebrew (MacOS or Linux)
+Install with `homebrew`:
+```shell
+brew install grpcui
+```
+
 ### From Source
 You can use the `go` tool to install `grpcui`:
 ```shell


### PR DESCRIPTION
Added installation instruction using `homebrew` since its the easiest and fastest, and less prone to errors as well.