### PR TITLE
Disable CGO for improved compatibility across distros

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,8 @@ dev_build_version=$(shell git describe --tags --always --dirty)
 
 export PATH := $(shell pwd)/.tmp/protoc/bin:$(PATH)
 export PROTOC_VERSION := 22.0
+# Disable CGO for improved compatibility across distros
+export CGO_ENABLED=0
 
 # TODO: run golint and errcheck, but only to catch *new* violations and
 # decide whether to change code or not (e.g. we need to be able to whitelist
@@ -91,7 +93,8 @@ errcheck:
 
 .PHONY: test
 test:
-	go test -race ./...
+	# The race detector requires CGO: https://github.com/golang/go/issues/6508
+	CGO_ENABLED=1 go test -race ./...
 
 .tmp/protoc/bin/protoc: ./Makefile ./download_protoc.sh
 	./download_protoc.sh


### PR DESCRIPTION
This PR disables CGO so we don't have any dependencies on C libraries expected to be found in the environment, in order to achieve a better compatibility across distros.

Tested by running `make install` before and after the changes and inspecting the produced binary from a Linux machine (Debian in this case).
**Before**
```sh
ldd $(which grpcui)
	linux-vdso.so.1 (0x00007ffe2cb2e000)
	libresolv.so.2 => /lib/x86_64-linux-gnu/libresolv.so.2 (0x00007fcc13946000)
	libpthread.so.0 => /lib/x86_64-linux-gnu/libpthread.so.0 (0x00007fcc13924000)
	libc.so.6 => /lib/x86_64-linux-gnu/libc.so.6 (0x00007fcc13750000)
	/lib64/ld-linux-x86-64.so.2 (0x00007fcc1396a000)
```
**After**
```sh
ldd $(which grpcui)
	not a dynamic executable
```

Follow-up of the same changes in `grpcurl`: https://github.com/fullstorydev/grpcurl/pull/420
