### PR TITLE
Update Tarball URL used by Homebrew

### DIFF
--- a/releasing/README.md
+++ b/releasing/README.md
@@ -74,7 +74,7 @@ The last step is to update the Homebrew recipe to use the latest version. First,
 
 ```sh
 # download the source archive from GitHub
-URL=https://github.com/fullstorydev/grpcui/archive/v2.3.4.tar.gz
+URL=https://github.com/fullstorydev/grpcui/archive/refs/tags/v2.3.4.tar.gz
 curl -L -o tmp.tgz $URL
 # and compute the SHA
 SHA="$(sha256sum < tmp.tgz | awk '{ print $1 }')"

--- a/releasing/do-release.sh
+++ b/releasing/do-release.sh
@@ -54,7 +54,7 @@ rm VERSION
 
 # Homebrew release
 
-URL="https://github.com/fullstorydev/grpcui/archive/${VERSION}.tar.gz"
+URL="https://github.com/fullstorydev/grpcui/archive/refs/tags/${VERSION}.tar.gz"
 curl -L -o tmp.tgz "$URL"
 SHA="$(sha256sum < tmp.tgz | awk '{ print $1 }')"
 rm tmp.tgz


### PR DESCRIPTION
While releasing `grpcurl@v1.8.9`, I encountered an error described in https://github.com/fullstorydev/grpcurl/pull/421.

A similar change happened in `grpcui`'s Homebrew formula: https://github.com/Homebrew/homebrew-core/commit/c845f04a193ac8b5a03004ddc763aad23e1d8eca

We probably need to update the Tarball URL used to update our Homebrew formula as well.