### PR TITLE
Support `grpc.reflection.v1.ServerReflection`

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ GUI. This lets you interactively construct requests to send to a gRPC server.
 
 With this tool you can also browse the schema for gRPC services, which is presented as a
 list of available endpoints. This is enabled either by querying a server that supports
-[server reflection](https://github.com/grpc/grpc/blob/master/src/proto/grpc/reflection/v1alpha/reflection.proto),
+[server reflection](https://github.com/grpc/grpc/blob/master/src/proto/grpc/reflection/v1/reflection.proto),
 by reading proto source files, or by loading in compiled "protoset" files (files that contain
 encoded file [descriptor protos](https://github.com/google/protobuf/blob/master/src/google/protobuf/descriptor.proto)).
 In fact, the way the tool transforms JSON request data into a binary encoded protobuf
@@ -82,7 +82,7 @@ run `make install`.
 If you encounter compile errors, you could have out-dated versions of `grpcui`'s
 dependencies. You can update the dependencies by running `make updatedeps`.
 
-### Running without install 
+### Running without install
 
 ```
 go run ./cmd/grpcui/grpcui.go -plaintext localhost:9019
@@ -230,7 +230,7 @@ into text. The sections below document the supported sources and what command-li
 are needed to use them.
 
 ### Server Reflection
-Without any additional command-line flags, `grpcui` will try to use [server reflection](https://github.com/grpc/grpc/blob/master/src/proto/grpc/reflection/v1alpha/reflection.proto).
+Without any additional command-line flags, `grpcui` will try to use [server reflection](https://github.com/grpc/grpc/blob/master/src/proto/grpc/reflection/v1/reflection.proto).
 
 Examples for how to set up server reflection can be found [here](https://github.com/grpc/grpc/blob/master/doc/server-reflection.md#known-implementations).
 

--- a/cmd/grpcui/grpcui.go
+++ b/cmd/grpcui/grpcui.go
@@ -35,7 +35,6 @@ import (
 	"google.golang.org/grpc/grpclog"
 	"google.golang.org/grpc/keepalive"
 	"google.golang.org/grpc/metadata"
-	reflectpb "google.golang.org/grpc/reflection/grpc_reflection_v1alpha"
 
 	// Register gzip compressor so compressed responses will work
 	_ "google.golang.org/grpc/encoding/gzip"
@@ -564,7 +563,7 @@ func main() {
 	if reflection.val {
 		md := grpcurl.MetadataFromHeaders(append(addlHeaders, reflHeaders...))
 		refCtx := metadata.NewOutgoingContext(ctx, md)
-		refClient = grpcreflect.NewClientV1Alpha(refCtx, reflectpb.NewServerReflectionClient(cc))
+		refClient = grpcreflect.NewClientAuto(refCtx, cc)
 		refClient.AllowMissingFileDescriptors()
 		reflSource := grpcurl.DescriptorSourceFromServer(ctx, refClient)
 		if fileSource != nil {
@@ -859,7 +858,7 @@ func getMethods(source grpcurl.DescriptorSource, configs map[string]*svcConfig) 
 
 	var descs []*desc.MethodDescriptor
 	for _, svc := range allServices {
-		if svc == "grpc.reflection.v1alpha.ServerReflection" {
+		if svc == "grpc.reflection.v1alpha.ServerReflection" || svc == "grpc.reflection.v1.ServerReflection" {
 			continue
 		}
 		d, err := source.FindSymbol(svc)

--- a/files.go
+++ b/files.go
@@ -5,7 +5,6 @@ import (
 	"github.com/jhump/protoreflect/grpcreflect"
 	"golang.org/x/net/context"
 	"google.golang.org/grpc"
-	rpb "google.golang.org/grpc/reflection/grpc_reflection_v1alpha"
 	"google.golang.org/protobuf/reflect/protoreflect"
 	"google.golang.org/protobuf/reflect/protoregistry"
 
@@ -18,8 +17,7 @@ import (
 // reflection. (See "google.golang.org/grpc/reflection" for more on service
 // reflection.)
 func AllFilesViaReflection(ctx context.Context, cc grpc.ClientConnInterface) ([]*desc.FileDescriptor, error) {
-	stub := rpb.NewServerReflectionClient(cc)
-	cli := grpcreflect.NewClientV1Alpha(ctx, stub)
+	cli := grpcreflect.NewClientAuto(ctx, cc)
 	source := grpcurl.DescriptorSourceFromServer(ctx, cli)
 	return grpcurl.GetAllFiles(source)
 }

--- a/methods.go
+++ b/methods.go
@@ -6,7 +6,6 @@ import (
 	"golang.org/x/net/context"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/reflection"
-	rpb "google.golang.org/grpc/reflection/grpc_reflection_v1alpha"
 )
 
 // AllMethodsForServices returns a slice that contains the method descriptors
@@ -47,8 +46,7 @@ func AllMethodsForServer(svr *grpc.Server) ([]*desc.MethodDescriptor, error) {
 // This automatically skips the reflection service, since it is assumed this is not
 // a desired inclusion.
 func AllMethodsViaReflection(ctx context.Context, cc grpc.ClientConnInterface) ([]*desc.MethodDescriptor, error) {
-	stub := rpb.NewServerReflectionClient(cc)
-	cli := grpcreflect.NewClientV1Alpha(ctx, stub)
+	cli := grpcreflect.NewClientAuto(ctx, cc)
 	svcNames, err := cli.ListServices()
 	if err != nil {
 		return nil, err
@@ -59,7 +57,8 @@ func AllMethodsViaReflection(ctx context.Context, cc grpc.ClientConnInterface) (
 		if err != nil {
 			return nil, err
 		}
-		if sd.GetFullyQualifiedName() == "grpc.reflection.v1alpha.ServerReflection" {
+		fullyQualifiedName := sd.GetFullyQualifiedName()
+		if fullyQualifiedName == "grpc.reflection.v1alpha.ServerReflection" || fullyQualifiedName == "grpc.reflection.v1.ServerReflection" {
 			continue // skip reflection service
 		}
 		descs = append(descs, sd)
@@ -78,7 +77,8 @@ func AllMethodsViaInProcess(svr reflection.GRPCServer) ([]*desc.MethodDescriptor
 	}
 	var descs []*desc.ServiceDescriptor
 	for _, sd := range sds {
-		if sd.GetFullyQualifiedName() == "grpc.reflection.v1alpha.ServerReflection" {
+		fullyQualifiedName := sd.GetFullyQualifiedName()
+		if fullyQualifiedName == "grpc.reflection.v1alpha.ServerReflection" || fullyQualifiedName == "grpc.reflection.v1.ServerReflection" {
 			continue // skip reflection service
 		}
 		descs = append(descs, sd)

--- a/testing/cmd/testsvr/testsvr.go
+++ b/testing/cmd/testsvr/testsvr.go
@@ -17,7 +17,7 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/reflection"
-	reflectionpb "google.golang.org/grpc/reflection/grpc_reflection_v1alpha"
+	reflectionpb "google.golang.org/grpc/reflection/grpc_reflection_v1"
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/anypb"
@@ -49,7 +49,7 @@ func main() {
 
 	svr := grpc.NewServer()
 	RegisterKitchenSinkServer(svr, &testSvr{})
-	refSvc := reflection.NewServer(reflection.ServerOptions{
+	refSvc := reflection.NewServerV1(reflection.ServerOptions{
 		Services:           svr,
 		DescriptorResolver: sourceinfo.GlobalFiles,
 		ExtensionResolver:  sourceinfo.GlobalFiles,


### PR DESCRIPTION
Currently, `grpc.reflection.v1.ServerReflection` is shown in the list of `Service Name`. This PR removes it as well as `grpc.reflection.v1alpha.ServerReflection`.

Also, change to use `v1` protocol if we can use it.