### PR TITLE
Correctly initialise gRPCurl text area

### DIFF
--- a/internal/resources/webform/webform.js
+++ b/internal/resources/webform/webform.js
@@ -154,9 +154,6 @@ window.initGRPCForm = function(services, svcDescs, mtdDescs, invokeURI, metadata
         // set raw request text
         updateJSONRequest(requestObj);
 
-        // init grpcCurl text
-        updateCurlCommand(requestObj);
-
         // enable the invoke button
         resetInvoke(true);
 


### PR DESCRIPTION
# Description

https://github.com/fullstorydev/grpcui/pull/241 introduced feature where a `grpcurl` command would be rendered. The `grpcurl` could then be copied and run in terminal repeatedly.

# Issue
After some use, I have noticed a small bug where on initial page load, the `grpcurl` would contain an incorrectly serialized payload `[Object object]`.  Expectation is that the payload should contain a valid JSON data. At a minimum this has to be an empty JSON object `{}`, or anything that has been entered either from the first tab, or manually in the Request box.

<img width="886" alt="Screenshot 2024-10-05 at 21 31 03" src="https://github.com/user-attachments/assets/b8daa122-1892-487f-9b2f-6c48c1cbaefe">

# Root cause

The issue is introduced by line [https://github.com/fullstorydev/grpcui/blob/master/internal/resources/webform/webform.js#L158](webform.js#L158) which calls, which calls `updateCurlCommand(requestObj);`. The problem with this line is that `requestObj` is not a string parameter. This object ends up being concatenated to a string, and gets translated to `Object object`.

To trace this issue down I have instrumented [updateCurlCommand()](https://github.com/fullstorydev/grpcui/blob/master/internal/resources/webform/webform.js#L2106) function and logged out how many times it was called and the stack trace along with it. It turned out that on page load this function was called twice.  Surprisingly, the first call contained the correct JSON value, but the second not. 

The first call was made from [updateJsonRequest](https://github.com/fullstorydev/grpcui/blob/master/internal/resources/webform/webform.js#L2128C14-L2128C31), which converted request object to `string` and passed that to `updateCurlCommand`.  

# Fix
It turns out, that the second call to `updateCurlCommand` is not needed, and thus can be removed. 