### PR TITLE
Replace removed goreleaser archives.replacements configuration

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -23,11 +23,9 @@ archives:
       - goos: windows
         format: zip
     name_template: >-
-      {{ .ProjectName }}_{{ .Version }}_
-      {{- if eq .Os "darwin" }}osx
-      {{- else }}{{ .Os }}{{ end }}_
-      {{- if eq .Arch "amd64" }}x86_64
-      {{- else if eq .Arch "386" }}x86_32
-      {{- else }}{{ .Arch }}{{ end }}
+      {{ .Binary }}_{{ .Version }}_
+      {{- if eq .Os "darwin" }}osx{{ else }}{{ .Os }}{{ end }}_
+      {{- if eq .Arch "amd64" }}x86_64{{ else if eq .Arch "386" }}x86_32{{ else }}{{ .Arch }}{{ end }}
+      {{- with .Arm }}v{{ . }}{{ end }}{{ with .Mips }}_{{ . }}{{ end }}{{ if not (eq .Amd64 "v1") }}{{ .Amd64 }}{{ end }}
     files:
       - LICENSE

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -22,9 +22,12 @@ archives:
     format_overrides:
       - goos: windows
         format: zip
-    replacements:
-      amd64: x86_64
-      386: x86_32
-      darwin: osx
+    name_template: >-
+      {{ .ProjectName }}_{{ .Version }}_
+      {{- if eq .Os "darwin" }}osx
+      {{- else }}{{ .Os }}{{ end }}_
+      {{- if eq .Arch "amd64" }}x86_64
+      {{- else if eq .Arch "386" }}x86_32
+      {{- else }}{{ .Arch }}{{ end }}
     files:
       - LICENSE


### PR DESCRIPTION
The `archives.replacements` field from the `goreleaser` configuration file was [removed](https://goreleaser.com/deprecations/#archivesreplacements).
It's stopping us from releasing a new version:
```
goreleaser release --clean
  • starting release...
  ⨯ release failed after 0s                  error=yaml: unmarshal errors:
  line 25: field replacements not found in type config.Archive
```

The suggested alternative is to use `archives.name_template`.

Tested by running `goreleaser release --skip publish` locally, inspecting the built archive names, and comparing them to past releases:
```
  • archives
    • creating                                       archive=dist/grpcui_1.4.2_linux_x86_32.tar.gz
    • creating                                       archive=dist/grpcui_1.4.2_windows_x86_64.zip
    • creating                                       archive=dist/grpcui_1.4.2_linux_x86_64.tar.gz
    • creating                                       archive=dist/grpcui_1.4.2_linux_arm64.tar.gz
    • creating                                       archive=dist/grpcui_1.4.2_osx_arm64.tar.gz
    • creating                                       archive=dist/grpcui_1.4.2_windows_x86_32.zip
    • creating                                       archive=dist/grpcui_1.4.2_osx_x86_64.tar.gz
```