### PR TITLE
Run full set of checks using Go 1.23

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,15 +13,8 @@ jobs:
     working_directory: ~/repo
     docker:
       - image: cimg/go:1.21
-    steps:
-      - checkout
-      - run:
-          name: Run tests and linters
-          command: |
-            make ci
+    steps: *simple_job_steps
 
-  # TODO: Need updates to some static analyzer tools to support 1.22.
-  # After those are updated, move the full linting from 1.21 to this latest release.
   build-1-22:
     working_directory: ~/repo
     docker:
@@ -32,7 +25,12 @@ jobs:
     working_directory: ~/repo
     docker:
       - image: cimg/go:1.23
-    steps: *simple_job_steps
+    steps:
+      - checkout
+      - run:
+          name: Run tests and linters
+          command: |
+            make ci
 
 workflows:
   pr-build-test:

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ ci: deps checkgofmt checkgenerate vet staticcheck ineffassign predeclared test
 
 .PHONY: deps
 deps:
-	go get -d -v -t ./...
+	go get -v -t ./...
 	go mod tidy
 
 .PHONY: updatedeps

--- a/Makefile
+++ b/Makefile
@@ -78,7 +78,7 @@ ineffassign:
 
 .PHONY: predeclared
 predeclared:
-	@go install github.com/nishanths/predeclared@5f2f810c9ae6
+	@go install github.com/nishanths/predeclared@245576f9a85c96ea16c750df3887f1d827f01e9c
 	predeclared ./...
 
 # Intentionally omitted from CI, but target here for ad-hoc reports.

--- a/Makefile
+++ b/Makefile
@@ -68,7 +68,7 @@ vet:
 
 .PHONY: staticcheck
 staticcheck:
-	@go install honnef.co/go/tools/cmd/staticcheck@v0.4.3
+	@go install honnef.co/go/tools/cmd/staticcheck@v0.5.1
 	staticcheck ./...
 
 .PHONY: ineffassign


### PR DESCRIPTION
Some of our static check tools were too old and didn't work with Go >= 1.20.

This PR bumps the versions of those tools so they can work with the current latest Go version (1.23) and runs the full set of CI checks on that version.