### PR TITLE
Remove double updateCurlCommand call

### DIFF
--- a/internal/resources/webform/webform.js
+++ b/internal/resources/webform/webform.js
@@ -154,9 +154,6 @@ window.initGRPCForm = function(services, svcDescs, mtdDescs, invokeURI, metadata
         // set raw request text
         updateJSONRequest(requestObj);
 
-        // init grpcCurl text
-        updateCurlCommand(requestObj);
-
         // enable the invoke button
         resetInvoke(true);
 


### PR DESCRIPTION
updateJSONRequest already calls the function with the object converted to a json string. No need to double call it, the second time with the raw object

Probably a simpler version of https://github.com/fullstorydev/grpcui/pull/340