### PR TITLE
feat: Allow overriding grpc command displayed in UI

### DIFF
--- a/internal/resources/webform/webform-template.html
+++ b/internal/resources/webform/webform-template.html
@@ -144,7 +144,7 @@
     ];
 
     window.target = {{ .Target }};
-    window.gRPCurlOptions = {{ .GRPCurlOptions }};
+    window.gRPCurlCmd = {{ .GRPCurlCmd }};
 
     initGRPCForm(services, svcDescs, mtdDescs, '{{ .InvokeURI }}', '{{ .MetadataURI }}', {{ .Debug }}, headers);
 })();

--- a/internal/resources/webform/webform.js
+++ b/internal/resources/webform/webform.js
@@ -2113,9 +2113,7 @@ window.initGRPCForm = function(services, svcDescs, mtdDescs, invokeURI, metadata
 
     let gRPCurlTextArea = $("#grpc-curl-text");
     function updateCurlCommand(requestDataJson) {
-        const grpcOpts = window.gRPCurlOptions ? ' ' + window.gRPCurlOptions : '';
-
-        let metadataStr = "";
+        let grpcCmd = window.gRPCurlCmd;
 
         const service = $("#grpc-service").val();
         const method = $("#grpc-method").val();
@@ -2129,11 +2127,11 @@ window.initGRPCForm = function(services, svcDescs, mtdDescs, invokeURI, metadata
             const name = $(cells[0]).val();
             const val = $(cells[1]).val();
             if (name !== "") {
-                metadataStr += ` -H "${name}: ${val}"`;
+                grpcCmd += ` -H "${name}: ${val}"`;
             }
         }
 
-        gRPCurlTextArea.text(`grpcurl${grpcOpts}${metadataStr} -d '${requestDataJson}' ${window.target} ${service}.${method}`);
+        gRPCurlTextArea.text(`${grpcCmd} -d '${requestDataJson}' ${window.target} ${service}.${method}`);
     }
 
     var jsonRawTextArea = $("#grpc-request-raw-text");

--- a/standalone/opts.go
+++ b/standalone/opts.go
@@ -219,9 +219,15 @@ func WithClientDebug(debug bool) HandlerOption {
 	})
 }
 
+func WithGRPCCmd(cmdLine []string) HandlerOption {
+	return optFunc(func(opts *handlerOptions) {
+		opts.gRPCurlCmd = cmdLine
+	})
+}
+
 func WithGRPCOptions(options []string) HandlerOption {
 	return optFunc(func(opts *handlerOptions) {
-		opts.gRPCurlOptions = options
+		opts.gRPCurlCmd = append([]string{"grpcurl"}, options...)
 	})
 }
 
@@ -245,7 +251,7 @@ type handlerOptions struct {
 	emitDefaults        bool
 	invokeVerbosity     int
 	debug               *bool
-	gRPCurlOptions      []string
+	gRPCurlCmd          []string
 }
 
 func (opts *handlerOptions) addlServedResources() []*resource {

--- a/standalone/standalone.go
+++ b/standalone/standalone.go
@@ -45,10 +45,10 @@ const csrfHeaderName = "x-grpcui-csrf-token"
 // be handling a sub-path (e.g. handling "/rpc-ui/") then use http.StripPrefix.
 func Handler(ch grpcdynamic.Channel, target string, methods []*desc.MethodDescriptor, files []*desc.FileDescriptor, opts ...HandlerOption) http.Handler {
 	uiOpts := &handlerOptions{
-		indexTmpl:      defaultIndexTemplate,
-		css:            grpcui.WebFormSampleCSS(),
-		cssPublic:      true,
-		gRPCurlOptions: nil,
+		indexTmpl:  defaultIndexTemplate,
+		css:        grpcui.WebFormSampleCSS(),
+		cssPublic:  true,
+		gRPCurlCmd: []string{"grpcurl"},
 	}
 	for _, o := range opts {
 		o.apply(uiOpts)
@@ -79,7 +79,7 @@ func Handler(ch grpcdynamic.Channel, target string, methods []*desc.MethodDescri
 	formOpts := grpcui.WebFormOptions{
 		DefaultMetadata: uiOpts.defaultMetadata,
 		Debug:           uiOpts.debug,
-		GRPCurlOptions:  uiOpts.gRPCurlOptions,
+		GRPCurlCmd:      uiOpts.gRPCurlCmd,
 	}
 	webFormHTML := grpcui.WebFormContentsWithOptions("invoke", "metadata", target, methods, formOpts)
 	indexContents := getIndexContents(uiOpts.indexTmpl, target, webFormHTML, uiOpts.tmplResources)

--- a/webform.go
+++ b/webform.go
@@ -72,7 +72,7 @@ type WebFormOptions struct {
 	// debug is enabled).
 	Debug *bool
 	// Any options that will be rendered before grpcurl in the grpccurl/raw request box
-	GRPCurlOptions []string
+	GRPCurlCmd []string
 }
 
 // WebFormContentsWithOptions is the same as WebFormContents except that it
@@ -93,7 +93,7 @@ func WebFormContentsWithOptions(invokeURI, metadataURI string, target string, de
 		DefaultMetadata []metadataEntry
 		Debug           bool
 		Target          string
-		GRPCurlOptions  template.JS
+		GRPCurlCmd      template.JS
 	}{
 		InvokeURI:   invokeURI,
 		MetadataURI: metadataURI,
@@ -104,11 +104,11 @@ func WebFormContentsWithOptions(invokeURI, metadataURI string, target string, de
 		Target:      target,
 	}
 
-	gRPCOptionsJSONStr, err := json.Marshal(strings.Join(opts.GRPCurlOptions, " "))
+	gRPCOptionsJSONStr, err := json.Marshal(strings.Join(opts.GRPCurlCmd, " "))
 	if err != nil {
 		panic(fmt.Errorf("Error marshaling to JSON: %w", err))
 	}
-	params.GRPCurlOptions = template.JS(gRPCOptionsJSONStr)
+	params.GRPCurlCmd = template.JS(gRPCOptionsJSONStr)
 	if opts.Debug != nil {
 		params.Debug = *opts.Debug
 	}


### PR DESCRIPTION
Scenario:

Which to create copy and paste able commands to share with coworkers. Current implementation would copy the exact paths for -cacerts (eg /home/halkeye/staff.key) instead of variables (eg $HOME/staff.key)

Add override flag so the command can be anything you want eg
```
grpcui -plaintext -override-grpccurl-cmd="grpcurl -key ~/.ssh/staff.key -cert ~/.ssh/staff.crt" localhost:8008
```