### PR TITLE
feat(webform): add service/method comboboxes with URL and localStorage restore

### DIFF
--- a/internal/resources/webform/webform-sample.css
+++ b/internal/resources/webform/webform-sample.css
@@ -20,6 +20,13 @@
     font-size: 14px;
 }
 
+.grpc-desc .grpc-combobox-input {
+    height: 30px;
+    font-size: 14px;
+    min-width: 280px;
+    padding: 4px 8px;
+}
+
 .grpc-desc pre {
     margin: 0 0 0 36px;
     padding-left: 20px;

--- a/internal/resources/webform/webform-sample.css
+++ b/internal/resources/webform/webform-sample.css
@@ -34,17 +34,6 @@
     color: #777;
 }
 
-button#grpc-descriptions-toggle {
-    position: absolute;
-    z-index: 3;
-    padding: 0;
-    margin-top: 6px;
-    margin-left: 10px;
-    border: none;
-    background: white;
-    font-size: 150%;
-}
-
 .grpc-desc div.grpc-form-label {
     font-size: 110%;
     width: 124px;
@@ -203,6 +192,17 @@ ol#grpc-request-examples {
     margin-bottom: 16px;
     font-family: "Courier New", Courier, monospace;
     font-size: 14px;
+}
+
+button#grpc-descriptions-toggle {
+    position: absolute;
+    z-index: 3;
+    padding: 0;
+    margin-top: 6px;
+    margin-left: 10px;
+    border: none;
+    background: white;
+    font-size: 150%;
 }
 
 textarea#grpc-request-raw-text {

--- a/internal/resources/webform/webform.js
+++ b/internal/resources/webform/webform.js
@@ -26,7 +26,6 @@ window.initGRPCForm = function(services, svcDescs, mtdDescs, invokeURI, metadata
             methodList.val(methods[0]);
         }
         syncComboboxInput("#grpc-method");
-        persistSelectionState();
         // implicit selection of first element does not
         // generate a change event, so we have to do this
         formMethodSelected(callback);
@@ -2642,9 +2641,6 @@ window.initGRPCForm = function(services, svcDescs, mtdDescs, invokeURI, metadata
 
     const setupCombobox = (selectSelector, inputId) => {
         const selectEl = $(selectSelector);
-        if (selectEl.length === 0 || selectEl.data("comboboxReady")) {
-            return;
-        }
 
         const inputEl = $("<input>", {
             id: inputId,
@@ -2654,16 +2650,17 @@ window.initGRPCForm = function(services, svcDescs, mtdDescs, invokeURI, metadata
             "aria-haspopup": "listbox",
         }).insertAfter(selectEl);
 
-        const readSource = () => getSelectOptions(selectEl);
         inputEl.val(selectEl.val() || "");
 
         inputEl.autocomplete({
             minLength: 0,
             delay: 0,
             source: function(req, resp) {
-                const options = readSource();
+                const options = getSelectOptions(selectEl);
+                // When user types an exact option value, put it first in the dropdown
+                // so it's pre-selected, then show remaining options for easy browsing
                 const exactMatchIndex = options.findIndex(item => item === req.term);
-                if (exactMatchIndex >= 0) {
+                if (exactMatchIndex !== -1) {
                     const exactMatch = options[exactMatchIndex];
                     const reordered = [exactMatch].concat(options.filter((item, index) => index !== exactMatchIndex));
                     resp(reordered);
@@ -2700,8 +2697,8 @@ window.initGRPCForm = function(services, svcDescs, mtdDescs, invokeURI, metadata
         selectEl.on("change.comboboxSync", function() {
             syncComboboxInput(selectSelector);
         });
-        selectEl.hide();
         inputEl.width(selectEl.outerWidth());
+        selectEl.hide();
         selectEl.data("comboboxInput", inputEl);
         selectEl.data("comboboxReady", true);
     };
@@ -2743,6 +2740,13 @@ window.initGRPCForm = function(services, svcDescs, mtdDescs, invokeURI, metadata
         }
         if (hasMethodForService(service, method)) {
             setStorageItem(methodStorageKey, method);
+        }
+        // Update URL query params to make the current selection shareable
+        if (hasService(service) && hasMethodForService(service, method)) {
+            const url = new URL(window.location);
+            url.searchParams.set("serviceName", service);
+            url.searchParams.set("methodName", method);
+            window.history.replaceState(null, "", url.toString());
         }
     };
 

--- a/internal/resources/webform/webform.js
+++ b/internal/resources/webform/webform.js
@@ -3,7 +3,7 @@ window.initGRPCForm = function(services, svcDescs, mtdDescs, invokeURI, metadata
     var descriptionsShown = false;
     var requestForm = $("#grpc-request-form");
 
-    function formServiceSelected(callback) {
+    function formServiceSelected(callback, preferredMethod) {
         var svcName = $("#grpc-service").val();
         var svcDesc = svcDescs[svcName];
         var methods = services[svcName];
@@ -17,10 +17,16 @@ window.initGRPCForm = function(services, svcDescs, mtdDescs, invokeURI, metadata
         var methodList = $("#grpc-method");
         methodList.empty();
         for (var i = 0; i < methods.length; i++) {
-            m = methods[i];
+            var m = methods[i];
             methodList.append($("<option>", {value: m, text: m}));
         }
-        $("#grpc-method option:first-of-type").select();
+        if (preferredMethod && methods.includes(preferredMethod)) {
+            methodList.val(preferredMethod);
+        } else if (methods.length > 0) {
+            methodList.val(methods[0]);
+        }
+        syncComboboxInput("#grpc-method");
+        persistSelectionState();
         // implicit selection of first element does not
         // generate a change event, so we have to do this
         formMethodSelected(callback);
@@ -41,6 +47,7 @@ window.initGRPCForm = function(services, svcDescs, mtdDescs, invokeURI, metadata
         $.ajax(metadataURI + "?method=" + fullMethod)
             .done(function(data) {
                 buildRequestForm(data);
+                persistSelectionState();
                 callback?.();
             })
             .fail(function(data, status) {
@@ -2575,6 +2582,169 @@ window.initGRPCForm = function(services, svcDescs, mtdDescs, invokeURI, metadata
 
     const historyStorageKey = `grpcui-history-${window.location.host}-${target}`;
     const expandDescStorageKey = `grpcui-expand-description`;
+    const serviceStorageKey = `grpcui-last-service-${window.location.host}-${target}`;
+    const methodStorageKey = `grpcui-last-method-${window.location.host}-${target}`;
+
+    const getStorageItem = (key) => {
+        try {
+            return localStorage.getItem(key);
+        } catch (e) {
+            return null;
+        }
+    };
+
+    const setStorageItem = (key, value) => {
+        try {
+            localStorage.setItem(key, value);
+        } catch (e) {}
+    };
+
+    const hasService = (serviceName) => Boolean(serviceName && services[serviceName]);
+
+    const hasMethodForService = (serviceName, methodName) =>
+        Boolean(hasService(serviceName) && methodName && services[serviceName].includes(methodName));
+
+    const getSelectOptions = (selectEl) => {
+        const options = [];
+        $(selectEl).find("option").each(function() {
+            const val = $(this).val();
+            if (val) {
+                options.push(val);
+            }
+        });
+        return options;
+    };
+
+    const resolveOptionValue = (selectEl, rawValue) => {
+        if (!rawValue) {
+            return null;
+        }
+        const options = getSelectOptions(selectEl);
+        if (options.includes(rawValue)) {
+            return rawValue;
+        }
+        const lowered = rawValue.toLowerCase();
+        for (let i = 0; i < options.length; i++) {
+            if (options[i].toLowerCase() === lowered) {
+                return options[i];
+            }
+        }
+        return null;
+    };
+
+    const syncComboboxInput = (selectSelector) => {
+        const selectEl = $(selectSelector);
+        const inputEl = selectEl.data("comboboxInput");
+        if (inputEl && inputEl.length) {
+            inputEl.val(selectEl.val() || "");
+        }
+    };
+
+    const setupCombobox = (selectSelector, inputId) => {
+        const selectEl = $(selectSelector);
+        if (selectEl.length === 0 || selectEl.data("comboboxReady")) {
+            return;
+        }
+
+        const inputEl = $("<input>", {
+            id: inputId,
+            type: "text",
+            class: "grpc-combobox-input ui-widget ui-widget-content ui-state-default ui-corner-left",
+            "aria-autocomplete": "list",
+            "aria-haspopup": "listbox",
+        }).insertAfter(selectEl);
+
+        const readSource = () => getSelectOptions(selectEl);
+        inputEl.val(selectEl.val() || "");
+
+        inputEl.autocomplete({
+            minLength: 0,
+            delay: 0,
+            source: function(req, resp) {
+                const options = readSource();
+                const exactMatchIndex = options.findIndex(item => item === req.term);
+                if (exactMatchIndex >= 0) {
+                    const exactMatch = options[exactMatchIndex];
+                    const reordered = [exactMatch].concat(options.filter((item, index) => index !== exactMatchIndex));
+                    resp(reordered);
+                    return;
+                }
+                const term = (req.term || "").toLowerCase();
+                const matches = options.filter(item => item.toLowerCase().includes(term));
+                resp(matches);
+            },
+            select: function(_event, ui) {
+                const prev = selectEl.val();
+                const next = ui.item.value;
+                selectEl.val(next);
+                syncComboboxInput(selectSelector);
+                if (prev !== next) {
+                    selectEl.trigger("change");
+                }
+            },
+            change: function(_event, ui) {
+                const prev = selectEl.val();
+                const resolved = ui.item?.value || resolveOptionValue(selectEl, inputEl.val()) || selectEl.val();
+                selectEl.val(resolved);
+                syncComboboxInput(selectSelector);
+                if (prev !== resolved) {
+                    selectEl.trigger("change");
+                }
+            }
+        });
+
+        inputEl.on("focus", function() {
+            $(this).autocomplete("search", $(this).val());
+        });
+
+        selectEl.on("change.comboboxSync", function() {
+            syncComboboxInput(selectSelector);
+        });
+        selectEl.hide();
+        inputEl.width(selectEl.outerWidth());
+        selectEl.data("comboboxInput", inputEl);
+        selectEl.data("comboboxReady", true);
+    };
+
+    const resolveInitialSelection = () => {
+        const params = new URLSearchParams(window.location.search || "");
+        const serviceFromQuery = params.get("serviceName");
+        const methodFromQuery = params.get("methodName");
+        const serviceFromStorage = getStorageItem(serviceStorageKey);
+        const methodFromStorage = getStorageItem(methodStorageKey);
+
+        const serviceCandidates = [serviceFromQuery, serviceFromStorage, $("#grpc-service option:first").val()];
+        let service = null;
+        for (let i = 0; i < serviceCandidates.length; i++) {
+            if (hasService(serviceCandidates[i])) {
+                service = serviceCandidates[i];
+                break;
+            }
+        }
+
+        const methods = services[service] || [];
+        const methodCandidates = [methodFromQuery, methodFromStorage, methods[0]];
+        let method = null;
+        for (let i = 0; i < methodCandidates.length; i++) {
+            if (hasMethodForService(service, methodCandidates[i])) {
+                method = methodCandidates[i];
+                break;
+            }
+        }
+
+        return { service, method };
+    };
+
+    const persistSelectionState = () => {
+        const service = $("#grpc-service").val();
+        const method = $("#grpc-method").val();
+        if (hasService(service)) {
+            setStorageItem(serviceStorageKey, service);
+        }
+        if (hasMethodForService(service, method)) {
+            setStorageItem(methodStorageKey, method);
+        }
+    };
 
     const loadExamples = () => {
         $.ajax({
@@ -2798,22 +2968,20 @@ window.initGRPCForm = function(services, svcDescs, mtdDescs, invokeURI, metadata
         }
         $("#grpc-request-timeout input").val(timeout);
         $("#grpc-service").val(item.service);
+        syncComboboxInput("#grpc-service");
         formServiceSelected(() => {
-            $("#grpc-method").val(item.method);
-            formMethodSelected(() => {
-                updateJSONRequest(item.request.data)
-                validateJSON();
-                // remove all rows
-                $("tr").remove('.metadataRow');
-                // item.request.metadata will be undefined when using -examples
-                // and without setting in json file, here it needs to be verified
-                if (item.request.metadata) {
-                    for (let metadata of item.request.metadata) {
-                        addMetadataRow(metadata.name, metadata.value);
-                    }
+            updateJSONRequest(item.request.data)
+            validateJSON();
+            // remove all rows
+            $("tr").remove('.metadataRow');
+            // item.request.metadata will be undefined when using -examples
+            // and without setting in json file, here it needs to be verified
+            if (item.request.metadata) {
+                for (let metadata of item.request.metadata) {
+                    addMetadataRow(metadata.name, metadata.value);
                 }
-            });
-        });
+            }
+        }, item.method);
     }
 
     const clearExampleSelection = () => {
@@ -2898,8 +3066,17 @@ window.initGRPCForm = function(services, svcDescs, mtdDescs, invokeURI, metadata
     // data and metadata from URL hash fragment (and add a way for user to
     // get URL with hash fragment for currently selected method and data)
 
-    // initialize methods drop-down based on selected service
-    formServiceSelected();
+    setupCombobox("#grpc-service", "grpc-service-combobox");
+    setupCombobox("#grpc-method", "grpc-method-combobox");
+
+    const initialSelection = resolveInitialSelection();
+    if (hasService(initialSelection.service)) {
+        $("#grpc-service").val(initialSelection.service);
+        syncComboboxInput("#grpc-service");
+    }
+
+    // initialize methods drop-down based on selected service and preferred method
+    formServiceSelected(undefined, initialSelection.method);
 
     if (isUnset(headers) || headers.length === 0) {
         // add a single blank entry to request metadata table


### PR DESCRIPTION
https://github.com/user-attachments/assets/6f10876e-9dc7-4591-a8dc-bb9b418747e1

Hello, thank you for maintaining this awesome project!

I recently joined a team, and we have a lot of services. So to find a service I want, I had to read the list of options in the service selector to find and click the necessary one. So I added a few enhancements:

1. Comboboxes for "Service name" and "Method name". You now can type service name, e.g. `auth`, and then select (using mouse or keyboard) from the filtered list of options.
2. Persistance for "Service name" and "Method name". So when you close the grpcui, then after a while you come back, the same service and method names are selected (that were there the last time)
3. Taking "Service name" and "Method name" from URL. So let's say you're have a documentation for your services, there you can put links like `my-grpcui-instance.com/?serviceName=com.company.OrderService&methodName=GetOrder`, and when users click such a link, they go to the GRPC UI with the preselected service and method. Startup precedence is: query params -> localStorage -> first available service/method
