### PR TITLE
fix combobox reopen on click

### DIFF
--- a/internal/resources/webform/webform.js
+++ b/internal/resources/webform/webform.js
@@ -2691,7 +2691,7 @@ window.initGRPCForm = function(services, svcDescs, mtdDescs, invokeURI, metadata
             }
         });
 
-        inputEl.on("focus", function() {
+        inputEl.on("focus click", function() {
             $(this).autocomplete("search", $(this).val());
         });
 


### PR DESCRIPTION
when we select an item in the combobox, if we click it again it is not opening (unless we click somewhere else on the screen first). This PR fixes that.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line event binding change in combobox UI behavior with no backend or security impact.
> 
> **Overview**
> Fixes gRPC service/method comboboxes so the suggestion list opens again when you click the field right after picking a value, without having to blur away first.
> 
> The combobox text input only ran `autocomplete("search", …)` on **focus**. After a selection the input often stays focused, so another click did not refire that handler. The same handler is now bound to **`focus` and `click`**, so a click always reopens the dropdown with the current value.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a7770de97f3638b0b945545f74cdab5b9b87f3cd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->