### PR TITLE
update go releaser

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,3 +1,5 @@
+version: 2
+
 builds:
   - binary: grpcui
     main: ./cmd/grpcui
@@ -18,10 +20,10 @@ builds:
       - -s -w -X main.version=v{{.Version}}
 
 archives:
-  - format: tar.gz
+  - formats: [tar.gz]
     format_overrides:
       - goos: windows
-        format: zip
+        formats: [zip]
     name_template: >-
       {{ .Binary }}_{{ .Version }}_
       {{- if eq .Os "darwin" }}osx{{ else }}{{ .Os }}{{ end }}_

--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ install:
 
 .PHONY: release
 release:
-	@go install github.com/goreleaser/goreleaser@v1.21.0
+	@go install github.com/goreleaser/goreleaser/v2@v2.5.0
 	goreleaser release --clean
 
 .PHONY: docker


### PR DESCRIPTION
When trying to release grpcui, I got the following error

```
# golang.org/x/tools/internal/tokeninternal
../../go/pkg/mod/golang.org/x/tools@v0.13.0/internal/tokeninternal/tokeninternal.go:78:9: invalid array length -delta * delta (constant -256 of type int64)
make: *** [release] Error 1
```

Updating gorelease seems to fix the issue

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only release tooling and config change; no application runtime or security-sensitive logic is modified.
> 
> **Overview**
> Upgrades the release pipeline from **GoReleaser v1.21.0** to **v2.5.0** so `make release` works again (the PR author hit a build failure in `golang.org/x/tools` when using the older toolchain).
> 
> The **Makefile** now installs `github.com/goreleaser/goreleaser/v2@v2.5.0`. **`.goreleaser.yml`** is aligned with GoReleaser v2: adds `version: 2` and replaces archive `format` / `format_overrides.format` with the v2 `formats` list syntax (still `tar.gz` by default, `zip` on Windows).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9167596cb427a17d16fd834e76726be5d7a1efa2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->