### PR TITLE
fix go release yaml

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -20,10 +20,10 @@ builds:
       - -s -w -X main.version=v{{.Version}}
 
 archives:
-  - formats: [tar.gz]
+  - format: tar.gz
     format_overrides:
       - goos: windows
-        formats: [zip]
+        format: zip
     name_template: >-
       {{ .Binary }}_{{ .Version }}_
       {{- if eq .Os "darwin" }}osx{{ else }}{{ .Os }}{{ end }}_


### PR DESCRIPTION
It seems there was a mistake in the yaml config merged on the previous PR, reverting it

```
goreleaser release --clean
  ⨯ release failed after 0s                  error=yaml: unmarshal errors:
  line 23: field formats not found in type config.Archive
  line 26: field formats not found in type config.FormatOverride
make: *** [release] Error 1
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Release tooling config only; no runtime, auth, or application code changes.
> 
> **Overview**
> Fixes **GoReleaser release failures** caused by invalid archive config from a prior merge. The YAML used `formats` lists, which **do not exist** on `config.Archive` / `config.FormatOverride` in the project's **GoReleaser v2** setup (`version: 2` in `.goreleaser.yml`).
> 
> The diff switches archive settings to the v2 shape: default **`format: tar.gz`**, and for Windows overrides **`format: zip`** instead of `formats: [zip]`. Behavior is unchanged; only the schema matches what `goreleaser release --clean` expects.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4ec247ac8493f68edb6b40ae81641b286534b0be. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->