### PR TITLE
update go version in dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.23-alpine as builder
+FROM golang:1.25-alpine as builder
 MAINTAINER Fullstory Engineering
 
 # create non-privileged group and user


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Single-line base image version change with no runtime or application logic modifications.
> 
> **Overview**
> Updates the Docker **builder** stage base image from `golang:1.23-alpine` to `golang:1.25-alpine` so container builds use the same Go toolchain as `go.mod` (`go 1.25.0`). No application source or build flags change—only the compiler image version.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e50183433cf5eb47f2714eebeaf61e5cddde4c5d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->